### PR TITLE
Add an ethContext React context for dealing with Ethereum

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -17,6 +17,7 @@ import FramesHandlerContainer from './FramesHandler';
 import PaletteGridContainer from './PaletteGrid';
 import ResetContainer from './Reset';
 import SaveDrawingContainer from './SaveDrawing';
+import MintDrawingContainer from './MintDrawing';
 import NewProjectContainer from './NewProject';
 import SimpleNotificationContainer from './SimpleNotification';
 import SimpleSpinnerContainer from './SimpleSpinner';
@@ -94,6 +95,9 @@ export default class App extends React.Component {
                 <div className="app__mobile--group">
                   <div data-tooltip={helpOn ? 'New project' : null}>
                     <NewProjectContainer />
+                  </div>
+                  <div data-tooltip={helpOn ? 'Mint art' : null}>
+                    <MintDrawingContainer />
                   </div>
                   <div className="app__load-save-container">
                     <button

--- a/src/components/MintDrawing.jsx
+++ b/src/components/MintDrawing.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import shortid from 'shortid';
+import { useEthContext } from '../contexts/ethContext';
+import * as actionCreators from '../store/actions/actionCreators';
+import Grid from '../utils/grid';
+
+const MintDrawing = props => {
+  const { mintFn } = useEthContext();
+
+  const mint = () => {
+    const drawingToMint = {
+      activeFrame: props.activeFrame,
+      frames: props.frames,
+      paletteGridData: props.paletteGridData,
+      cellSize: props.cellSize,
+      columns: props.columns,
+      rows: props.rows,
+      animate: props.frames.size > 1,
+      id: shortid.generate()
+    };
+
+    const grid = new Grid(drawingToMint.activeFrame, drawingToMint.columns);
+    if (mintFn(grid.toGridArray())) {
+      props.actions.sendNotification('Drawing minted');
+    } else {
+      props.actions.sendNotification('Error minting');
+    }
+  };
+
+  return (
+    <div className="mint-drawing">
+      <button type="button" onClick={mint}>
+        MINT
+      </button>
+    </div>
+  );
+};
+
+const mapStateToProps = state => {
+  const frames = state.present.get('frames');
+  const activeFrameIndex = frames.get('activeIndex');
+  return {
+    activeFrame: frames.getIn(['list', activeFrameIndex]),
+    frames: frames.get('list'),
+    columns: frames.get('columns'),
+    rows: frames.get('rows'),
+    cellSize: state.present.get('cellSize'),
+    paletteGridData: state.present.getIn(['palette', 'grid'])
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  actions: bindActionCreators(actionCreators, dispatch)
+});
+
+const MintDrawingContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(MintDrawing);
+export default MintDrawingContainer;

--- a/src/contexts/ethContext.jsx
+++ b/src/contexts/ethContext.jsx
@@ -1,0 +1,42 @@
+import React, { useContext, createContext } from 'react';
+
+const EthContext = createContext(null);
+
+/**
+ * Add an ethContext React context and some scaffolding code such that the
+ * `PixelArt` component exposes some injection sites for functions that
+ * interact with the Ethereum chain. The `EthContextProvider` takes a
+ * function with the following signature:
+ *
+ * ```
+ * interface RGBA {
+ *     // r, g, and b are integers between [0, 255]
+ *     r: number,
+ *     g: number,
+ *     b: number,
+ *
+ *     // a is a float in [0, 1]
+ *     a: number
+ * }
+ *
+ * // grid is a 2D grid, so each inner array must be the same length
+ * (grid: Array<Array<RGBA>>): boolean
+ * ```
+ *
+ * The return value is whether minting succeeded or failed.
+ */
+function EthContextProvider({ mintFn, children }) {
+  return (
+    <EthContext.Provider value={{ mintFn }}>{children}</EthContext.Provider>
+  );
+}
+
+function useEthContext() {
+  const context = useContext(EthContext);
+  if (context === null) {
+    throw new Error('context is not initialized. Use EthContextProvider');
+  }
+  return context;
+}
+
+export { EthContextProvider, useEthContext };

--- a/src/css/components/_MintDrawing.css
+++ b/src/css/components/_MintDrawing.css
@@ -1,0 +1,9 @@
+.mint-drawing {
+  button {
+    @mixin button gray;
+
+    width: 100%;
+    padding: 0.5em;
+    margin-bottom: 0.6em;
+  }
+}

--- a/src/css/imports.css
+++ b/src/css/imports.css
@@ -19,6 +19,7 @@
 @import 'components/_LoadDrawing.css';
 @import 'components/_SaveDrawing.css';
 @import 'components/_NewProject.css';
+@import 'components/_MintDrawing.css';
 @import 'components/_UndoRedo.css';
 @import 'components/_App.css';
 @import 'components/_Reset.css';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,4 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PixelArt from './lib-index';
 
-ReactDOM.render(<PixelArt />, document.getElementById('app'));
+ReactDOM.render(
+  <PixelArt
+    mintFn={grid => {
+      console.log('Trying to mint.');
+      console.log(grid);
+    }}
+  />,
+  document.getElementById('app')
+);

--- a/src/lib-index.jsx
+++ b/src/lib-index.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import './css/imports.css'; // Import PostCSS files
 import configureStore from './store/configureStore';
+import { EthContextProvider } from './contexts/ethContext';
 import Root from './components/Root';
 
-export default function PixelArt() {
+export default function PixelArt({ mintFn }) {
   const [showEditor, setShowEditor] = useState(false);
   useEffect(() => {
     setShowEditor(true);
@@ -12,16 +13,20 @@ export default function PixelArt() {
   if (!showEditor) {
     return <div>Loading...</div>;
   }
-  return <PixelArtApp />;
+  return <PixelArtApp mintFn={mintFn} />;
 }
 
 // In case this code is pre-rendered by a server, it's simpler for us to have a
 // component that only gets rendered in the browser. Then we don't need to
 // worry about if all of the code is Node.js compatible because it can be gated
 // behind `useEffect`.
-function PixelArtApp() {
+function PixelArtApp({ mintFn }) {
   const devMode = process.env.NODE_ENV === 'development';
   const store = configureStore(devMode);
 
-  return <Root store={store} />;
+  return (
+    <EthContextProvider mintFn={mintFn}>
+      <Root store={store} />
+    </EthContextProvider>
+  );
 }

--- a/src/store/reducers/framesReducer.js
+++ b/src/store/reducers/framesReducer.js
@@ -73,8 +73,8 @@ const getFrame = (frames, frameId) => {
 
 const initFrames = (action = {}) => {
   const options = action.options || {};
-  const columns = parseInt(options.columns, 10) || 20;
-  const rows = parseInt(options.rows, 10) || 20;
+  const columns = parseInt(options.columns, 10) || 32;
+  const rows = parseInt(options.rows, 10) || 32;
   const list = resetIntervals(List([create(columns * rows)]));
   const hoveredIndex = undefined;
   return Map({

--- a/src/utils/cssParse.js
+++ b/src/utils/cssParse.js
@@ -8,11 +8,12 @@ import {
 const PIXELART_CSS_CLASS_NAME = 'pixelart-to-css';
 
 export function generatePixelDrawCss(frame, columns, cellSize, type) {
-  return getImageData(frame.get('grid'), {
+  const imageData = getImageData(frame.get('grid'), {
     format: type,
     pSize: cellSize,
     c: columns
   });
+  return imageData;
 }
 
 export function getCssImageClassOutput(frame, columns, cellSize) {

--- a/src/utils/grid.js
+++ b/src/utils/grid.js
@@ -1,0 +1,44 @@
+export default class Grid {
+  constructor(frame, columns) {
+    this.grid = frame.get('grid');
+    this.columns = columns;
+    this.rows = this.grid.size / columns;
+    if (Math.floor(this.rows) !== this.rows) {
+      throw new Error('Grid is not rectangular');
+    }
+  }
+
+  get(x, y) {
+    if (x < 0 || x >= this.columns) {
+      throw new Error(`x out of bounds [0, ${this.columns - 1}]`);
+    }
+    if (y < 0 || y >= this.rows) {
+      throw new Error(`y out of bounds [0, ${this.rows - 1}]`);
+    }
+
+    return Grid.strToRGBA(this.grid.get(this.rows * y + x));
+  }
+
+  static strToRGBA(rgbaStr) {
+    if (rgbaStr.trim() === '') {
+      return { r: 0, g: 0, b: 0, a: 0 };
+    }
+    const arr = rgbaStr
+      .slice(rgbaStr.indexOf('(') + 1, -1)
+      .split(', ')
+      .map(v => parseInt(v, 10));
+    return { r: arr[0], g: arr[1], b: arr[2], a: arr[3] };
+  }
+
+  toGridArray() {
+    const arr = [];
+    for (let j = 0; j < this.rows; j++) {
+      const rowArr = [];
+      for (let i = 0; i < this.columns; i++) {
+        rowArr.push(this.get(i, j));
+      }
+      arr.push(rowArr);
+    }
+    return arr;
+  }
+}

--- a/src/utils/startup.js
+++ b/src/utils/startup.js
@@ -1,5 +1,8 @@
 import * as actionCreators from '../store/actions/actionCreators';
-import { initStorage, getDataFromStorage } from './storage';
+import {
+  // initStorage,
+  getDataFromStorage
+} from './storage';
 
 /*
   Initial actions to dispatch:
@@ -34,7 +37,7 @@ const initialSetup = (dispatch, storage) => {
     }
   } else {
     // If no data initialize storage
-    initStorage(storage);
+    // initStorage(storage);
   }
 };
 


### PR DESCRIPTION
Add an ethContext React context and some scaffolding code such that the
`PixelArt` component exposes some injection sites for functions that
interact with the Ethereum chain. The `EthContextProvider` takes a
function with the following signature:

```
interface RGBA {
    // r, g, and b are integers between [0, 255]
    r: number,
    g: number,
    b: number,

    // a is a float in [0, 1]
    a: number
}

// grid is a 2D grid, so each inner array must be the same length
(grid: Array<Array<RGBA>>): boolean
```

The return value is whether minting succeeded or failed.

Also change default grid size and stop initial storage loading:

- Change default grid size
- When there is no data stored yet, do not load an example from storage