### PR TITLE
Modularize the CSS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[**.{js{,x},css}]
+indent_style = space
+indent_size = 2

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -64,7 +64,7 @@ export default class App extends React.Component {
     const { helpOn, modalType, modalOpen } = this.state;
     return (
       <div
-        className="app__main"
+        className="pixel-art-react-container app app__main"
         onMouseUp={this.onMouseUp}
         onTouchEnd={this.onMouseUp}
         onTouchCancel={this.onMouseUp}

--- a/src/css/_base.css
+++ b/src/css/_base.css
@@ -1,81 +1,74 @@
-html {
+.pixel-art-react-container {
   box-sizing: border-box;
   background-color: $color-scorpion;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: inherit;
-}
-
-html,
-body {
   position: relative;
   font-family: $font-pixel;
-}
-
-body {
   overflow: auto;
-}
 
-.app-container {
-  height: 100%;
-  width: 90%;
-  margin: 0 auto;
-  padding: 0;
-}
+  *,
+  *::before,
+  *::after {
+    box-sizing: inherit;
+  }
 
-h1 {
-  font-size: 2em;
-}
+  .app-container {
+    height: 100%;
+    width: 90%;
+    margin: 0 auto;
+    padding: 0;
+  }
 
-h2 {
-  font-size: 0.8em;
-  padding-right: 1em;
-  display: inline;
-  position: relative;
-  top: -0.9em;
-}
+  h1 {
+    font-size: 2em;
+  }
 
-h3 {
-  font-size: 1em;
-}
+  h2 {
+    font-size: 0.8em;
+    padding-right: 1em;
+    display: inline;
+    position: relative;
+    top: -0.9em;
+  }
 
-.block {
-  display: block;
-}
+  h3 {
+    font-size: 1em;
+  }
 
-.hidden {
-  display: none;
-}
+  .block {
+    display: block;
+  }
 
-.text-center {
-  text-align: center;
-}
+  .hidden {
+    display: none;
+  }
 
-.text-2xl {
-  font-size: 1.5rem;
-  line-height: 2rem;
-}
+  .text-center {
+    text-align: center;
+  }
 
-.mx-auto {
-  margin-left: auto;
-  margin-right: auto;
-}
+  .text-2xl {
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
 
-.flex {
-  display: flex;
-}
+  .mx-auto {
+    margin-left: auto;
+    margin-right: auto;
+  }
 
-.flex-wrap {
-  flex-wrap: wrap;
-}
+  .flex {
+    display: flex;
+  }
 
-.flex-col {
-  flex-direction: column;
-}
+  .flex-wrap {
+    flex-wrap: wrap;
+  }
 
-.flex-row {
-  flex-direction: row;
+  .flex-col {
+    flex-direction: column;
+  }
+
+  .flex-row {
+    flex-direction: row;
+  }
 }

--- a/src/css/_normalize.css
+++ b/src/css/_normalize.css
@@ -1,36 +1,37 @@
-/* stylelint-disable */
-/* prettier-ignore */
-/*! normalize.css v4.1.1 | MIT License | github.com/necolas/normalize.css */
+.pixel-art-react-container {
+  /* stylelint-disable */
+  /* prettier-ignore */
+  /*! normalize.css v4.1.1 | MIT License | github.com/necolas/normalize.css */
 
-/**
+  /**
  * 1. Change the default font family in all browsers (opinionated).
  * 2. Prevent adjustments of font size after orientation changes in IE and iOS.
  */
 
-html {
-  font-family: sans-serif; /* 1 */
-  -ms-text-size-adjust: 100%; /* 2 */
-  -webkit-text-size-adjust: 100%; /* 2 */
-}
+  html {
+    font-family: sans-serif; /* 1 */
+    -ms-text-size-adjust: 100%; /* 2 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+  }
 
-/**
+  /**
  * Remove the margin in all browsers (opinionated).
  */
 
-body {
-  margin: 0;
-}
+  body {
+    margin: 0;
+  }
 
-/* HTML5 display definitions
+  /* HTML5 display definitions
    ========================================================================== */
 
-/**
+  /**
  * Add the correct display in IE 9-.
  * 1. Add the correct display in Edge, IE, and Firefox.
  * 2. Add the correct display in IE.
  */
 
-article,
+  article,
 aside,
 details, /* 1 */
 figcaption,
@@ -42,384 +43,385 @@ menu,
 nav,
 section,
 summary {
-  /* 1 */
-  display: block;
-}
+    /* 1 */
+    display: block;
+  }
 
-/**
+  /**
  * Add the correct display in IE 9-.
  */
 
-audio,
-canvas,
-progress,
-video {
-  display: inline-block;
-}
+  audio,
+  canvas,
+  progress,
+  video {
+    display: inline-block;
+  }
 
-/**
+  /**
  * Add the correct display in iOS 4-7.
  */
 
-audio:not([controls]) {
-  display: none;
-  height: 0;
-}
+  audio:not([controls]) {
+    display: none;
+    height: 0;
+  }
 
-/**
+  /**
  * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
 
-progress {
-  vertical-align: baseline;
-}
+  progress {
+    vertical-align: baseline;
+  }
 
-/**
+  /**
  * Add the correct display in IE 10-.
  * 1. Add the correct display in IE.
  */
 
-template, /* 1 */
+  template, /* 1 */
 [hidden] {
-  display: none;
-}
+    display: none;
+  }
 
-/* Links
+  /* Links
    ========================================================================== */
 
-/**
+  /**
  * 1. Remove the gray background on active links in IE 10.
  * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
  */
 
-a {
-  background-color: transparent; /* 1 */
-  -webkit-text-decoration-skip: objects; /* 2 */
-}
+  a {
+    background-color: transparent; /* 1 */
+    -webkit-text-decoration-skip: objects; /* 2 */
+  }
 
-/**
+  /**
  * Remove the outline on focused links when they are also active or hovered
  * in all browsers (opinionated).
  */
 
-a:active,
-a:hover {
-  outline-width: 0;
-}
+  a:active,
+  a:hover {
+    outline-width: 0;
+  }
 
-/* Text-level semantics
+  /* Text-level semantics
    ========================================================================== */
 
-/**
+  /**
  * 1. Remove the bottom border in Firefox 39-.
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 
-abbr[title] {
-  border-bottom: none; /* 1 */
-  text-decoration: underline; /* 2 */
-  text-decoration: underline dotted; /* 2 */
-}
+  abbr[title] {
+    border-bottom: none; /* 1 */
+    text-decoration: underline; /* 2 */
+    text-decoration: underline dotted; /* 2 */
+  }
 
-/**
+  /**
  * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
  */
 
-b,
-strong {
-  font-weight: inherit;
-}
+  b,
+  strong {
+    font-weight: inherit;
+  }
 
-/**
+  /**
  * Add the correct font weight in Chrome, Edge, and Safari.
  */
 
-b,
-strong {
-  font-weight: bolder;
-}
+  b,
+  strong {
+    font-weight: bolder;
+  }
 
-/**
+  /**
  * Add the correct font style in Android 4.3-.
  */
 
-dfn {
-  font-style: italic;
-}
+  dfn {
+    font-style: italic;
+  }
 
-/**
+  /**
  * Correct the font size and margin on `h1` elements within `section` and
  * `article` contexts in Chrome, Firefox, and Safari.
  */
 
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
+  h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+  }
 
-/**
+  /**
  * Add the correct background and color in IE 9-.
  */
 
-mark {
-  background-color: #ff0;
-  color: #000;
-}
+  mark {
+    background-color: #ff0;
+    color: #000;
+  }
 
-/**
+  /**
  * Add the correct font size in all browsers.
  */
 
-small {
-  font-size: 80%;
-}
+  small {
+    font-size: 80%;
+  }
 
-/**
+  /**
  * Prevent `sub` and `sup` elements from affecting the line height in
  * all browsers.
  */
 
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
 
-sub {
-  bottom: -0.25em;
-}
+  sub {
+    bottom: -0.25em;
+  }
 
-sup {
-  top: -0.5em;
-}
+  sup {
+    top: -0.5em;
+  }
 
-/* Embedded content
+  /* Embedded content
    ========================================================================== */
 
-/**
+  /**
  * Remove the border on images inside links in IE 10-.
  */
 
-img {
-  border-style: none;
-}
+  img {
+    border-style: none;
+  }
 
-/**
+  /**
  * Hide the overflow in IE.
  */
 
-svg:not(:root) {
-  overflow: hidden;
-}
+  svg:not(:root) {
+    overflow: hidden;
+  }
 
-/* Grouping content
+  /* Grouping content
    ========================================================================== */
 
-/**
+  /**
  * 1. Correct the inheritance and scaling of font size in all browsers.
  * 2. Correct the odd `em` font sizing in all browsers.
  */
 
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace; /* 1 */
-  font-size: 1em; /* 2 */
-}
+  code,
+  kbd,
+  pre,
+  samp {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
 
-/**
+  /**
  * Add the correct margin in IE 8.
  */
 
-figure {
-  margin: 1em 40px;
-}
+  figure {
+    margin: 1em 40px;
+  }
 
-/**
+  /**
  * 1. Add the correct box sizing in Firefox.
  * 2. Show the overflow in Edge and IE.
  */
 
-hr {
-  box-sizing: content-box; /* 1 */
-  height: 0; /* 1 */
-  overflow: visible; /* 2 */
-}
+  hr {
+    box-sizing: content-box; /* 1 */
+    height: 0; /* 1 */
+    overflow: visible; /* 2 */
+  }
 
-/* Forms
+  /* Forms
    ========================================================================== */
 
-/**
+  /**
  * 1. Change font properties to `inherit` in all browsers (opinionated).
  * 2. Remove the margin in Firefox and Safari.
  */
 
-button,
-input,
-optgroup,
-select,
-textarea {
-  font: inherit; /* 1 */
-  margin: 0; /* 2 */
-}
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font: inherit; /* 1 */
+    margin: 0; /* 2 */
+  }
 
-/**
+  /**
  * Restore the font weight unset by the previous rule.
  */
 
-optgroup {
-  font-weight: bold;
-}
+  optgroup {
+    font-weight: bold;
+  }
 
-/**
+  /**
  * Show the overflow in IE.
  * 1. Show the overflow in Edge.
  */
 
-button,
-input {
-  /* 1 */
-  overflow: visible;
-}
+  button,
+  input {
+    /* 1 */
+    overflow: visible;
+  }
 
-/**
+  /**
  * Remove the inheritance of text transform in Edge, Firefox, and IE.
  * 1. Remove the inheritance of text transform in Firefox.
  */
 
-button,
-select {
-  /* 1 */
-  text-transform: none;
-}
+  button,
+  select {
+    /* 1 */
+    text-transform: none;
+  }
 
-/**
+  /**
  * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
  *    controls in Android 4.
  * 2. Correct the inability to style clickable types in iOS and Safari.
  */
 
-button,
+  button,
 html [type="button"], /* 1 */
 [type="reset"],
 [type="submit"] {
-  -webkit-appearance: button; /* 2 */
-}
+    -webkit-appearance: button; /* 2 */
+  }
 
-/**
+  /**
  * Remove the inner border and padding in Firefox.
  */
 
-button::-moz-focus-inner,
-[type='button']::-moz-focus-inner,
-[type='reset']::-moz-focus-inner,
-[type='submit']::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
+  button::-moz-focus-inner,
+  [type='button']::-moz-focus-inner,
+  [type='reset']::-moz-focus-inner,
+  [type='submit']::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
 
-/**
+  /**
  * Restore the focus styles unset by the previous rule.
  */
 
-button:-moz-focusring,
-[type='button']:-moz-focusring,
-[type='reset']:-moz-focusring,
-[type='submit']:-moz-focusring {
-  outline: 1px dotted ButtonText;
-}
+  button:-moz-focusring,
+  [type='button']:-moz-focusring,
+  [type='reset']:-moz-focusring,
+  [type='submit']:-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
 
-/**
+  /**
  * Change the border, margin, and padding in all browsers (opinionated).
  */
 
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em;
-}
+  fieldset {
+    border: 1px solid #c0c0c0;
+    margin: 0 2px;
+    padding: 0.35em 0.625em 0.75em;
+  }
 
-/**
+  /**
  * 1. Correct the text wrapping in Edge and IE.
  * 2. Correct the color inheritance from `fieldset` elements in IE.
  * 3. Remove the padding so developers are not caught out when they zero out
  *    `fieldset` elements in all browsers.
  */
 
-legend {
-  box-sizing: border-box; /* 1 */
-  color: inherit; /* 2 */
-  display: table; /* 1 */
-  max-width: 100%; /* 1 */
-  padding: 0; /* 3 */
-  white-space: normal; /* 1 */
-}
+  legend {
+    box-sizing: border-box; /* 1 */
+    color: inherit; /* 2 */
+    display: table; /* 1 */
+    max-width: 100%; /* 1 */
+    padding: 0; /* 3 */
+    white-space: normal; /* 1 */
+  }
 
-/**
+  /**
  * Remove the default vertical scrollbar in IE.
  */
 
-textarea {
-  overflow: auto;
-}
+  textarea {
+    overflow: auto;
+  }
 
-/**
+  /**
  * 1. Add the correct box sizing in IE 10-.
  * 2. Remove the padding in IE 10-.
  */
 
-[type='checkbox'],
-[type='radio'] {
-  box-sizing: border-box; /* 1 */
-  padding: 0; /* 2 */
-}
+  [type='checkbox'],
+  [type='radio'] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+  }
 
-/**
+  /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
 
-[type='number']::-webkit-inner-spin-button,
-[type='number']::-webkit-outer-spin-button {
-  height: auto;
-}
+  [type='number']::-webkit-inner-spin-button,
+  [type='number']::-webkit-outer-spin-button {
+    height: auto;
+  }
 
-/**
+  /**
  * 1. Correct the odd appearance in Chrome and Safari.
  * 2. Correct the outline style in Safari.
  */
 
-[type='search'] {
-  -webkit-appearance: textfield; /* 1 */
-  outline-offset: -2px; /* 2 */
-}
+  [type='search'] {
+    -webkit-appearance: textfield; /* 1 */
+    outline-offset: -2px; /* 2 */
+  }
 
-/**
+  /**
  * Remove the inner padding and cancel buttons in Chrome and Safari on OS X.
  */
 
-[type='search']::-webkit-search-cancel-button,
-[type='search']::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
+  [type='search']::-webkit-search-cancel-button,
+  [type='search']::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
 
-/**
+  /**
  * Correct the text style of placeholders in Chrome, Edge, and Safari.
  */
 
-::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
+  ::-webkit-input-placeholder {
+    color: inherit;
+    opacity: 0.54;
+  }
 
-/**
+  /**
  * 1. Correct the inability to style clickable types in iOS and Safari.
  * 2. Change font properties to `inherit` in Safari.
  */
 
-::-webkit-file-upload-button {
-  -webkit-appearance: button; /* 1 */
-  font: inherit; /* 2 */
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button; /* 1 */
+    font: inherit; /* 2 */
+  }
 }

--- a/src/css/_utils.css
+++ b/src/css/_utils.css
@@ -1,55 +1,57 @@
-/**
+.pixel-art-react-container {
+  /**
  * Tooltip
  */
 
-[data-tooltip] {
-  position: relative;
-  cursor: pointer;
-  text-align: center;
-}
+  [data-tooltip] {
+    position: relative;
+    cursor: pointer;
+    text-align: center;
+  }
 
-[data-tooltip]::before,
-[data-tooltip]::after {
-  position: absolute;
-  opacity: 0;
-  transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out,
-    transform 0.2s cubic-bezier(0.71, 1.7, 0.77, 1.24);
-  transform: translate3d(0, 0, 0);
-  pointer-events: none;
-  bottom: 100%;
-  left: 50%;
-}
+  [data-tooltip]::before,
+  [data-tooltip]::after {
+    position: absolute;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out,
+      transform 0.2s cubic-bezier(0.71, 1.7, 0.77, 1.24);
+    transform: translate3d(0, 0, 0);
+    pointer-events: none;
+    bottom: 100%;
+    left: 50%;
+  }
 
-[data-tooltip]::before {
-  z-index: 1001;
-  border: 6px solid transparent;
-  background: transparent;
-  content: '';
-  margin-left: -6px;
-  margin-bottom: -12px;
-  border-top-color: black;
-  border-top-color: #4caf50;
-}
+  [data-tooltip]::before {
+    z-index: 1001;
+    border: 6px solid transparent;
+    background: transparent;
+    content: '';
+    margin-left: -6px;
+    margin-bottom: -12px;
+    border-top-color: black;
+    border-top-color: #4caf50;
+  }
 
-[data-tooltip]::after {
-  z-index: 1000;
-  padding: 8px;
-  width: 160px;
-  background-color: black;
-  background-color: #4caf50;
-  color: white;
-  content: attr(data-tooltip);
-  font-size: 14px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin-left: -80px;
-}
+  [data-tooltip]::after {
+    z-index: 1000;
+    padding: 8px;
+    width: 160px;
+    background-color: black;
+    background-color: #4caf50;
+    color: white;
+    content: attr(data-tooltip);
+    font-size: 14px;
+    line-height: 1.2;
+    font-weight: normal;
+    margin-left: -80px;
+  }
 
-[data-tooltip]:hover::before,
-[data-tooltip]:hover::after,
-[data-tooltip]:focus::before,
-[data-tooltip]:focus::after {
-  visibility: visible;
-  opacity: 1;
-  transform: translateY(-12px);
+  [data-tooltip]:hover::before,
+  [data-tooltip]:hover::after,
+  [data-tooltip]:focus::before,
+  [data-tooltip]:focus::after {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(-12px);
+  }
 }

--- a/src/css/components/_App.css
+++ b/src/css/components/_App.css
@@ -1,4 +1,4 @@
-#app {
+.pixel-art-react-container.app {
   .app__main-container,
   .app__central-container {
     lost-utility: clearfix;

--- a/src/css/components/_Bucket.css
+++ b/src/css/components/_Bucket.css
@@ -1,7 +1,9 @@
-.bucket {
-  @mixin icon bucket;
+.pixel-art-react-container {
+  .bucket {
+    @mixin icon bucket;
 
-  &:hover {
-    cursor: pointer;
+    &:hover {
+      cursor: pointer;
+    }
   }
 }

--- a/src/css/components/_CellInfo.css
+++ b/src/css/components/_CellInfo.css
@@ -1,5 +1,7 @@
-.cellinfo {
-  color: $color-silver;
-  text-align: center;
-  margin-top: 1em;
+.pixel-art-react-container {
+  .cellinfo {
+    color: $color-silver;
+    text-align: center;
+    margin-top: 1em;
+  }
 }

--- a/src/css/components/_CellSize.css
+++ b/src/css/components/_CellSize.css
@@ -1,15 +1,17 @@
-.cell-size {
-  border: 3px solid $color-boulder;
-  background-color: $color-mineShaft;
-  color: $color-silver;
-  text-align: center;
+.pixel-art-react-container {
+  .cell-size {
+    border: 3px solid $color-boulder;
+    background-color: $color-mineShaft;
+    color: $color-silver;
+    text-align: center;
 
-  label,
-  input {
-    padding-top: 0.2em;
-  }
+    label,
+    input {
+      padding-top: 0.2em;
+    }
 
-  label {
-    display: block;
+    label {
+      display: block;
+    }
   }
 }

--- a/src/css/components/_Checkbox.css
+++ b/src/css/components/_Checkbox.css
@@ -1,30 +1,32 @@
-.checkbox {
-  border: none;
-  text-align: center;
-  margin: 0 auto;
-  padding: 1em 0;
+.pixel-art-react-container {
+  .checkbox {
+    border: none;
+    text-align: center;
+    margin: 0 auto;
+    padding: 1em 0;
 
-  label {
-    span {
-      padding: 0.6em 1em;
-      transition: all 0.3s;
-    }
-
-    input {
-      display: none;
-
-      &:checked + span {
-        color: white;
-        background-color: black;
+    label {
+      span {
+        padding: 0.6em 1em;
+        transition: all 0.3s;
       }
 
-      &:not(:checked) + span {
-        &:hover {
-          box-shadow: 0 0 0 2px $color-scorpion inset;
+      input {
+        display: none;
+
+        &:checked + span {
+          color: white;
+          background-color: black;
+        }
+
+        &:not(:checked) + span {
+          &:hover {
+            box-shadow: 0 0 0 2px $color-scorpion inset;
+          }
         }
       }
-    }
 
-    margin: 0 0.5em;
+      margin: 0 0.5em;
+    }
   }
 }

--- a/src/css/components/_ColorPicker.css
+++ b/src/css/components/_ColorPicker.css
@@ -1,11 +1,13 @@
-.color-picker {
-  .color-picker__button {
-    @mixin icon paint-brush;
+.pixel-art-react-container {
+  .color-picker {
+    .color-picker__button {
+      @mixin icon paint-brush;
 
-    display: block;
-  }
+      display: block;
+    }
 
-  &:hover {
-    cursor: pointer;
+    &:hover {
+      cursor: pointer;
+    }
   }
 }

--- a/src/css/components/_CopyCss.css
+++ b/src/css/components/_CopyCss.css
@@ -1,21 +1,23 @@
-.copy-css {
-  h2 {
-    padding: 2em 0 1em;
-    margin-bottom: 0;
-    font-size: 1em;
-    display: block;
-    text-align: center;
+.pixel-art-react-container {
+  .copy-css {
+    h2 {
+      padding: 2em 0 1em;
+      margin-bottom: 0;
+      font-size: 1em;
+      display: block;
+      text-align: center;
 
-    span {
-      color: $color-tamarillo;
+      span {
+        color: $color-tamarillo;
+      }
     }
-  }
 
-  .copy-css__string {
-    overflow-x: scroll;
-    background-color: $color-mineShaft;
-    color: $color-silver;
-    padding: 0.5em;
-    text-align: left;
+    .copy-css__string {
+      overflow-x: scroll;
+      background-color: $color-mineShaft;
+      color: $color-silver;
+      padding: 0.5em;
+      text-align: left;
+    }
   }
 }

--- a/src/css/components/_CssDisplay.css
+++ b/src/css/components/_CssDisplay.css
@@ -1,12 +1,14 @@
-.css-display {
-  position: absolute;
-  top: -1.6em;
-  left: 0;
-  opacity: 0.1;
-  z-index: -1;
-  padding: 1em;
-  margin-top: 1em;
-  color: black;
-  user-select: none;
-  font-size: 0.8em;
+.pixel-art-react-container {
+  .css-display {
+    position: absolute;
+    top: -1.6em;
+    left: 0;
+    opacity: 0.1;
+    z-index: -1;
+    padding: 1em;
+    margin-top: 1em;
+    color: black;
+    user-select: none;
+    font-size: 0.8em;
+  }
 }

--- a/src/css/components/_Dimensions.css
+++ b/src/css/components/_Dimensions.css
@@ -1,4 +1,6 @@
-.dimensions {
-  margin: 1em 0 0;
-  padding: 0.5em 0;
+.pixel-art-react-container {
+  .dimensions {
+    margin: 1em 0 0;
+    padding: 0.5em 0;
+  }
 }

--- a/src/css/components/_DownloadDrawing.css
+++ b/src/css/components/_DownloadDrawing.css
@@ -1,6 +1,8 @@
-.download-btn {
-  @mixin button brown;
+.pixel-art-react-container {
+  .download-btn {
+    @mixin button brown;
 
-  margin: 1.5em auto;
-  display: table;
+    margin: 1.5em auto;
+    display: table;
+  }
 }

--- a/src/css/components/_Duration.css
+++ b/src/css/components/_Duration.css
@@ -1,16 +1,18 @@
-.duration {
-  margin-top: 1em;
-  border: 3px solid $color-boulder;
-  background-color: $color-mineShaft;
-  color: $color-silver;
-  text-align: center;
+.pixel-art-react-container {
+  .duration {
+    margin-top: 1em;
+    border: 3px solid $color-boulder;
+    background-color: $color-mineShaft;
+    color: $color-silver;
+    text-align: center;
 
-  label,
-  input {
-    padding-top: 0.2em;
-  }
+    label,
+    input {
+      padding-top: 0.2em;
+    }
 
-  label {
-    display: block;
+    label {
+      display: block;
+    }
   }
 }

--- a/src/css/components/_Eraser.css
+++ b/src/css/components/_Eraser.css
@@ -1,7 +1,9 @@
-.eraser {
-  @mixin icon eraser;
+.pixel-art-react-container {
+  .eraser {
+    @mixin icon eraser;
 
-  &:hover {
-    cursor: pointer;
+    &:hover {
+      cursor: pointer;
+    }
   }
 }

--- a/src/css/components/_EyeDropper.css
+++ b/src/css/components/_EyeDropper.css
@@ -1,7 +1,9 @@
-.eyedropper {
-  @mixin icon eyedropper;
+.pixel-art-react-container {
+  .eyedropper {
+    @mixin icon eyedropper;
 
-  &:hover {
-    cursor: pointer;
+    &:hover {
+      cursor: pointer;
+    }
   }
 }

--- a/src/css/components/_Frame.css
+++ b/src/css/components/_Frame.css
@@ -1,67 +1,69 @@
-.frame {
-  border: 1px solid $color-mineShaft;
-  background-color: $color-silver;
-  color: white;
-  width: 70px;
-  height: 84px;
-  margin: 0 0.3em;
-  flex: 0 0 auto;
-  position: relative;
-  overflow: hidden;
-  opacity: 0.4;
-
-  .delete,
-  .duplicate {
-    position: absolute;
+.pixel-art-react-container {
+  .frame {
+    border: 1px solid $color-mineShaft;
+    background-color: $color-silver;
     color: white;
-    right: 0;
-    background-color: $color-mineShaft;
-    border: 1px solid $color-tundora;
-    padding: 0.1em;
-  }
-
-  .delete {
-    @mixin icon trash;
-
-    font-size: 1.2em;
-    top: 0;
-    border-width: 0 0 2px 2px;
-  }
-
-  .duplicate {
-    @mixin icon duplicate;
-
-    bottom: 23px;
-    border-width: 2px 0 0 2px;
-  }
-
-  .frame__percentage {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    height: 23px;
-    border-top: 2px solid $color-tundora;
-  }
-
-  &.active {
-    border: 2px solid $color-tamarillo;
-    opacity: 1;
-
-    .delete {
-      cursor: no-drop;
-    }
-
-    .duplicate {
-      cursor: copy;
-    }
+    width: 70px;
+    height: 84px;
+    margin: 0 0.3em;
+    flex: 0 0 auto;
+    position: relative;
+    overflow: hidden;
+    opacity: 0.4;
 
     .delete,
     .duplicate {
-      border-color: $color-tamarillo;
+      position: absolute;
+      color: white;
+      right: 0;
+      background-color: $color-mineShaft;
+      border: 1px solid $color-tundora;
+      padding: 0.1em;
+    }
+
+    .delete {
+      @mixin icon trash;
+
+      font-size: 1.2em;
+      top: 0;
+      border-width: 0 0 2px 2px;
+    }
+
+    .duplicate {
+      @mixin icon duplicate;
+
+      bottom: 23px;
+      border-width: 2px 0 0 2px;
     }
 
     .frame__percentage {
-      border-color: $color-tamarillo;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      height: 23px;
+      border-top: 2px solid $color-tundora;
+    }
+
+    &.active {
+      border: 2px solid $color-tamarillo;
+      opacity: 1;
+
+      .delete {
+        cursor: no-drop;
+      }
+
+      .duplicate {
+        cursor: copy;
+      }
+
+      .delete,
+      .duplicate {
+        border-color: $color-tamarillo;
+      }
+
+      .frame__percentage {
+        border-color: $color-tamarillo;
+      }
     }
   }
 }

--- a/src/css/components/_FramesHandler.css
+++ b/src/css/components/_FramesHandler.css
@@ -1,23 +1,25 @@
-.frames-handler {
-  lost-utility: clearfix;
+.pixel-art-react-container {
+  .frames-handler {
+    lost-utility: clearfix;
 
-  .frames-handler__add {
-    @mixin button gray;
+    .frames-handler__add {
+      @mixin button gray;
 
-    height: 86px;
-    float: left;
-  }
+      height: 86px;
+      float: left;
+    }
 
-  .frame-handler__list {
-    display: flex;
-    background-color: $color-back-frames;
-    padding: 0.2em;
-
-    .list__container {
-      height: 85px;
+    .frame-handler__list {
       display: flex;
-      flex-wrap: nowrap;
-      padding-bottom: 0.5em;
+      background-color: $color-back-frames;
+      padding: 0.2em;
+
+      .list__container {
+        height: 85px;
+        display: flex;
+        flex-wrap: nowrap;
+        padding-bottom: 0.5em;
+      }
     }
   }
 }

--- a/src/css/components/_LoadDrawing.css
+++ b/src/css/components/_LoadDrawing.css
@@ -1,84 +1,86 @@
-.load-drawing {
-  text-align: center;
-  h2 {
-    padding: 2em 0 0;
-    margin-bottom: 0;
-    font-size: 1.2em;
+.pixel-art-react-container {
+  .load-drawing {
     text-align: center;
+    h2 {
+      padding: 2em 0 0;
+      margin-bottom: 0;
+      font-size: 1.2em;
+      text-align: center;
 
-    display: flex;
-    flex-direction: column;
-    overflow: auto;
-    min-width: auto;
-  }
+      display: flex;
+      flex-direction: column;
+      overflow: auto;
+      min-width: auto;
+    }
 
-  .load-drawing__container {
-    overflow: auto;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    text-align: center;
+    .load-drawing__container {
+      overflow: auto;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      text-align: center;
 
-    &.empty {
-      overflow-y: hidden;
+      &.empty {
+        overflow-y: hidden;
+        display: block;
+      }
+
+      .load-drawing__drawing {
+        position: relative;
+        border: 3px solid black;
+        cursor: pointer;
+        flex: 0 1 auto;
+        margin: 0.5em;
+        padding-right: 2em;
+
+        .drawing__delete {
+          @mixin icon trash;
+
+          position: absolute;
+          font-size: 1.7em;
+          color: white;
+          top: 0;
+          right: 0;
+          cursor: no-drop;
+          padding: 0.1em;
+          background-color: $color-mineShaft;
+          border: 2px solid black;
+          border-width: 0 0 2px 2px;
+        }
+
+        .preview {
+          margin: 0 auto;
+        }
+      }
+    }
+
+    .load-drawing__export {
+      overflow-x: scroll;
+      width: 100%;
+      margin: 0 auto;
+      background-color: $color-mineShaft;
+      color: $color-silver;
+      padding: 0.5em;
+      text-align: left;
+    }
+
+    .load-drawing__import {
+      font-family: $font-monospace;
       display: block;
+      width: 90%;
+      resize: none;
+      height: 6em;
+      margin: 0 auto;
+      padding: 0.5em;
+      background-color: $color-mineShaft;
+      color: $color-silver;
     }
 
-    .load-drawing__drawing {
-      position: relative;
-      border: 3px solid black;
-      cursor: pointer;
-      flex: 0 1 auto;
-      margin: 0.5em;
-      padding-right: 2em;
+    .import__button {
+      @mixin button red;
 
-      .drawing__delete {
-        @mixin icon trash;
-
-        position: absolute;
-        font-size: 1.7em;
-        color: white;
-        top: 0;
-        right: 0;
-        cursor: no-drop;
-        padding: 0.1em;
-        background-color: $color-mineShaft;
-        border: 2px solid black;
-        border-width: 0 0 2px 2px;
-      }
-
-      .preview {
-        margin: 0 auto;
-      }
+      margin: 1.5em auto;
+      display: table;
     }
-  }
-
-  .load-drawing__export {
-    overflow-x: scroll;
-    width: 100%;
-    margin: 0 auto;
-    background-color: $color-mineShaft;
-    color: $color-silver;
-    padding: 0.5em;
-    text-align: left;
-  }
-
-  .load-drawing__import {
-    font-family: $font-monospace;
-    display: block;
-    width: 90%;
-    resize: none;
-    height: 6em;
-    margin: 0 auto;
-    padding: 0.5em;
-    background-color: $color-mineShaft;
-    color: $color-silver;
-  }
-
-  .import__button {
-    @mixin button red;
-
-    margin: 1.5em auto;
-    display: table;
   }
 }

--- a/src/css/components/_MintDrawing.css
+++ b/src/css/components/_MintDrawing.css
@@ -1,9 +1,11 @@
-.mint-drawing {
-  button {
-    @mixin button gray;
+.pixel-art-react-container {
+  .mint-drawing {
+    button {
+      @mixin button gray;
 
-    width: 100%;
-    padding: 0.5em;
-    margin-bottom: 0.6em;
+      width: 100%;
+      padding: 0.5em;
+      margin-bottom: 0.6em;
+    }
   }
 }

--- a/src/css/components/_Modal.css
+++ b/src/css/components/_Modal.css
@@ -1,39 +1,41 @@
-.modal {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  overflow-x: hidden;
-  .modal__header {
-    text-align: right;
-    padding-bottom: 1em;
-    button.close {
-      @mixin button blue;
-      padding: 0.4em 0.7em 0.3em 0.8em;
+.pixel-art-react-container {
+  .modal {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    overflow-x: hidden;
+    .modal__header {
+      text-align: right;
+      padding-bottom: 1em;
+      button.close {
+        @mixin button blue;
+        padding: 0.4em 0.7em 0.3em 0.8em;
+      }
     }
-  }
-  .preview {
-    margin: 0 auto;
-  }
-  .modal__body {
-    overflow: auto;
-  }
-  .modal__preview,
-  .modal__load {
-    .modal__preview--wrapper {
-      margin: 1em auto;
-      display: table;
+    .preview {
+      margin: 0 auto;
     }
-  }
+    .modal__body {
+      overflow: auto;
+    }
+    .modal__preview,
+    .modal__load {
+      .modal__preview--wrapper {
+        margin: 1em auto;
+        display: table;
+      }
+    }
 
-  .modal__load,
-  .modal__preview,
-  .modal__body {
-    fieldset {
-      padding: 1em 0;
+    .modal__load,
+    .modal__preview,
+    .modal__body {
+      fieldset {
+        padding: 1em 0;
 
-      label {
-        margin: 1em 0.5em;
-        display: inline-block;
+        label {
+          margin: 1em 0.5em;
+          display: inline-block;
+        }
       }
     }
   }

--- a/src/css/components/_Move.css
+++ b/src/css/components/_Move.css
@@ -1,7 +1,9 @@
-.move {
-  @mixin icon move;
+.pixel-art-react-container {
+  .move {
+    @mixin icon move;
 
-  &:hover {
-    cursor: pointer;
+    &:hover {
+      cursor: pointer;
+    }
   }
 }

--- a/src/css/components/_NewProject.css
+++ b/src/css/components/_NewProject.css
@@ -1,9 +1,11 @@
-.new-project {
-  button {
-    @mixin button gray;
+.pixel-art-react-container {
+  .new-project {
+    button {
+      @mixin button gray;
 
-    width: 100%;
-    padding: 0.5em;
-    margin-bottom: 0.6em;
+      width: 100%;
+      padding: 0.5em;
+      margin-bottom: 0.6em;
+    }
   }
 }

--- a/src/css/components/_Output.css
+++ b/src/css/components/_Output.css
@@ -1,38 +1,40 @@
-.output {
-  position: relative;
-  text-align: center;
-  .copy-to-clipboard__container {
-    position: absolute;
-    left: 0;
-    top: 0;
-    button.copy-to-clipboard {
-      @mixin button brown;
-      padding: 0.1em 0.4em 0em 0.5em;
-      margin: 0.5em 0.5em 0;
-    }
-    span {
-      background-color: $color-shrub;
-      color: white;
-      padding: 0.1em 1.6em;
-      display: none;
-      &.show {
-        display: inline;
+.pixel-art-react-container {
+  .output {
+    position: relative;
+    text-align: center;
+    .copy-to-clipboard__container {
+      position: absolute;
+      left: 0;
+      top: 0;
+      button.copy-to-clipboard {
+        @mixin button brown;
+        padding: 0.1em 0.4em 0em 0.5em;
+        margin: 0.5em 0.5em 0;
+      }
+      span {
+        background-color: $color-shrub;
+        color: white;
+        padding: 0.1em 1.6em;
+        display: none;
+        &.show {
+          display: inline;
+        }
       }
     }
-  }
-  .output__text {
-    font-family: $font-monospace;
-    overflow-x: auto;
-    background-color: $color-mineShaft;
-    color: $color-silver;
-    padding: 3em 0.5em 0;
-    text-align: left;
-    display: block;
-    width: 100%;
-    resize: none;
-    height: 20em;
-  }
-  .output__pre {
-    white-space: pre;
+    .output__text {
+      font-family: $font-monospace;
+      overflow-x: auto;
+      background-color: $color-mineShaft;
+      color: $color-silver;
+      padding: 3em 0.5em 0;
+      text-align: left;
+      display: block;
+      width: 100%;
+      resize: none;
+      height: 20em;
+    }
+    .output__pre {
+      white-space: pre;
+    }
   }
 }

--- a/src/css/components/_PaletteColor.css
+++ b/src/css/components/_PaletteColor.css
@@ -1,9 +1,11 @@
-.palette-color {
-  float: left;
-  border: 2px solid $color-scorpion;
-  border-width: 2px;
+.pixel-art-react-container {
+  .palette-color {
+    float: left;
+    border: 2px solid $color-scorpion;
+    border-width: 2px;
 
-  &.selected {
-    border-color: white;
+    &.selected {
+      border-color: white;
+    }
   }
 }

--- a/src/css/components/_PaletteGrid.css
+++ b/src/css/components/_PaletteGrid.css
@@ -1,5 +1,7 @@
-.palette-grid {
-  lost-utility: clearfix;
-  text-align: center;
-  margin: 0.5em 0;
+.pixel-art-react-container {
+  .palette-grid {
+    lost-utility: clearfix;
+    text-align: center;
+    margin: 0.5em 0;
+  }
 }

--- a/src/css/components/_Picker.css
+++ b/src/css/components/_Picker.css
@@ -1,75 +1,77 @@
-.picker {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-
-  label.picker__columns {
-    @mixin icon columns;
-  }
-
-  label.picker__rows {
-    @mixin icon rows;
-  }
-
-  label.picker__columns,
-  label.picker__rows {
-    display: flex;
-    flex: 0 0 100%;
-  }
-
-  label {
-    flex: 0.5;
-    font-size: 2em !important;
-    color: $color-mineShaft;
-    position: relative;
-    margin: 0 auto;
-    text-align: center;
-
-    &::before {
-      display: inline-block;
-      width: 1.5em;
-      text-align: left;
-    }
-  }
-
-  .picker__container,
-  label {
+.pixel-art-react-container {
+  .picker {
     display: flex;
     align-items: center;
     justify-content: center;
-  }
+    text-align: center;
 
-  .picker__value,
-  .picker__buttons {
-    flex: 1;
-  }
+    label.picker__columns {
+      @mixin icon columns;
+    }
 
-  .picker__container {
-    font-family: $font-pixel;
-    font-size: 16px;
-    color: $color-silver;
-    background-color: $color-tundora;
-    border: 3px solid $color-boulder;
-    flex: 1;
+    label.picker__rows {
+      @mixin icon rows;
+    }
 
-    button {
+    label.picker__columns,
+    label.picker__rows {
+      display: flex;
+      flex: 0 0 100%;
+    }
+
+    label {
+      flex: 0.5;
+      font-size: 2em !important;
+      color: $color-mineShaft;
+      position: relative;
+      margin: 0 auto;
+      text-align: center;
+
+      &::before {
+        display: inline-block;
+        width: 1.5em;
+        text-align: left;
+      }
+    }
+
+    .picker__container,
+    label {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .picker__value,
+    .picker__buttons {
+      flex: 1;
+    }
+
+    .picker__container {
+      font-family: $font-pixel;
+      font-size: 16px;
       color: $color-silver;
-      background-color: $color-mineShaft;
-      border: none;
-      outline: none;
-      display: block;
-      width: 100%;
-      height: 2em;
-      border-left: 3px solid $color-boulder;
-    }
-
-    button:hover {
       background-color: $color-tundora;
-    }
+      border: 3px solid $color-boulder;
+      flex: 1;
 
-    .button-add {
-      border-bottom: 1px solid $color-boulder;
+      button {
+        color: $color-silver;
+        background-color: $color-mineShaft;
+        border: none;
+        outline: none;
+        display: block;
+        width: 100%;
+        height: 2em;
+        border-left: 3px solid $color-boulder;
+      }
+
+      button:hover {
+        background-color: $color-tundora;
+      }
+
+      .button-add {
+        border-bottom: 1px solid $color-boulder;
+      }
     }
   }
 }

--- a/src/css/components/_PixelGrid.css
+++ b/src/css/components/_PixelGrid.css
@@ -1,30 +1,32 @@
-.grid-container {
-  lost-utility: clearfix;
-  line-height: 0;
-  min-height: 1px;
-  margin: 0 auto;
-  width: 90%;
-  touch-action: none;
+.pixel-art-react-container {
+  .grid-container {
+    lost-utility: clearfix;
+    line-height: 0;
+    min-height: 1px;
+    margin: 0 auto;
+    width: 90%;
+    touch-action: none;
 
-  div {
-    float: left;
-    border: 1px solid $color-scorpion;
-    border-width: 0 1px 1px 0;
-  }
+    div {
+      float: left;
+      border: 1px solid $color-scorpion;
+      border-width: 0 1px 1px 0;
+    }
 
-  &.cell {
-    cursor: cell;
-  }
+    &.cell {
+      cursor: cell;
+    }
 
-  &.context-menu {
-    cursor: context-menu;
-  }
+    &.context-menu {
+      cursor: context-menu;
+    }
 
-  &.copy {
-    cursor: copy;
-  }
+    &.copy {
+      cursor: copy;
+    }
 
-  &.all-scroll {
-    cursor: all-scroll;
+    &.all-scroll {
+      cursor: all-scroll;
+    }
   }
 }

--- a/src/css/components/_PreviewBox.css
+++ b/src/css/components/_PreviewBox.css
@@ -1,42 +1,44 @@
-.preview-box {
-  & .buttons {
-    @mixin flex-row-center;
-    margin-bottom: 0.5rem;
-    div {
-      padding-left: 0.2em;
+.pixel-art-react-container {
+  .preview-box {
+    & .buttons {
+      @mixin flex-row-center;
+      margin-bottom: 0.5rem;
+      div {
+        padding-left: 0.2em;
+      }
     }
-  }
 
-  & .preview-box__container {
-    @mixin flex-row-center;
-    background-color: $color-back-frames;
-    padding: 0.8em 0 0.8em 0;
-    margin: 0.8em 0;
-    align-items: center;
-  }
+    & .preview-box__container {
+      @mixin flex-row-center;
+      background-color: $color-back-frames;
+      padding: 0.8em 0 0.8em 0;
+      margin: 0.8em 0;
+      align-items: center;
+    }
 
-  .play {
-    @mixin button gray;
-    @mixin icon play;
-  }
+    .play {
+      @mixin button gray;
+      @mixin icon play;
+    }
 
-  .pause {
-    @mixin button brown;
-    @mixin icon pause;
-  }
+    .pause {
+      @mixin button brown;
+      @mixin icon pause;
+    }
 
-  .screen-full {
-    @mixin button gray;
-    @mixin icon screen-full;
-  }
+    .screen-full {
+      @mixin button gray;
+      @mixin icon screen-full;
+    }
 
-  .screen-normal {
-    @mixin button gray;
-    @mixin icon screen-normal;
-  }
+    .screen-normal {
+      @mixin button gray;
+      @mixin icon screen-normal;
+    }
 
-  .frames {
-    @mixin button gray;
-    @mixin icon frames;
+    .frames {
+      @mixin button gray;
+      @mixin icon frames;
+    }
   }
 }

--- a/src/css/components/_RadioSelector.css
+++ b/src/css/components/_RadioSelector.css
@@ -1,30 +1,32 @@
-.radio-selector {
-  border: none;
-  text-align: center;
-  margin: 0 auto;
+.pixel-art-react-container {
+  .radio-selector {
+    border: none;
+    text-align: center;
+    margin: 0 auto;
 
-  label {
-    span {
-      padding: 0.6em 1em;
-      border: 1px solid $color-scorpion;
-      transition: all 0.3s;
-    }
-
-    input {
-      display: none;
-
-      &:checked + span {
-        color: white;
-        background-color: black;
+    label {
+      span {
+        padding: 0.6em 1em;
+        border: 1px solid $color-scorpion;
+        transition: all 0.3s;
       }
 
-      &:not(:checked) + span {
-        &:hover {
-          box-shadow: 0 0 0 2px $color-scorpion inset;
+      input {
+        display: none;
+
+        &:checked + span {
+          color: white;
+          background-color: black;
+        }
+
+        &:not(:checked) + span {
+          &:hover {
+            box-shadow: 0 0 0 2px $color-scorpion inset;
+          }
         }
       }
-    }
 
-    margin: 0 0.5em;
+      margin: 0 0.5em;
+    }
   }
 }

--- a/src/css/components/_Reset.css
+++ b/src/css/components/_Reset.css
@@ -1,7 +1,9 @@
-.reset {
-  width: 100%;
-  margin: 0.5em auto;
-  display: table;
+.pixel-art-react-container {
+  .reset {
+    width: 100%;
+    margin: 0.5em auto;
+    display: table;
 
-  @mixin button gray;
+    @mixin button gray;
+  }
 }

--- a/src/css/components/_SaveDrawing.css
+++ b/src/css/components/_SaveDrawing.css
@@ -1,7 +1,9 @@
-.save-drawing {
-  button {
-    @mixin button gray;
+.pixel-art-react-container {
+  .save-drawing {
+    button {
+      @mixin button gray;
 
-    width: 100%;
+      width: 100%;
+    }
   }
 }

--- a/src/css/components/_SimpleNotification.css
+++ b/src/css/components/_SimpleNotification.css
@@ -1,32 +1,34 @@
-.simple-notification {
-  background-color: #313131;
-  color: $color-silver;
-  width: 250px;
-  text-align: center;
-  padding: 1em;
-  position: fixed;
-  z-index: 1;
-  left: 50%;
-  margin-left: -125px;
-  top: 1em;
-  border: 1px solid orange;
-}
+.pixel-art-react-container {
+  .simple-notification {
+    background-color: #313131;
+    color: $color-silver;
+    width: 250px;
+    text-align: center;
+    padding: 1em;
+    position: fixed;
+    z-index: 1;
+    left: 50%;
+    margin-left: -125px;
+    top: 1em;
+    border: 1px solid orange;
+  }
 
-/* ReactCSSTransitionGroup related rules */
-.simple-notification-enter {
-  opacity: 0.01;
-}
+  /* ReactCSSTransitionGroup related rules */
+  .simple-notification-enter {
+    opacity: 0.01;
+  }
 
-.simple-notification-enter.simple-notification-enter-active {
-  opacity: 1;
-  transition: opacity 1000ms ease-in;
-}
+  .simple-notification-enter.simple-notification-enter-active {
+    opacity: 1;
+    transition: opacity 1000ms ease-in;
+  }
 
-.simple-notification-exit {
-  opacity: 1;
-}
+  .simple-notification-exit {
+    opacity: 1;
+  }
 
-.simple-notification-exit.simple-notification-exit-active {
-  opacity: 0.01;
-  transition: opacity 1000ms ease-out;
+  .simple-notification-exit.simple-notification-exit-active {
+    opacity: 0.01;
+    transition: opacity 1000ms ease-out;
+  }
 }

--- a/src/css/components/_SimpleSpinner.css
+++ b/src/css/components/_SimpleSpinner.css
@@ -1,45 +1,47 @@
-.simple-spinner {
-  position: absolute;
-  z-index: 1;
-  left: 0;
-  right: 0;
-  margin-left: auto;
-  margin-right: auto;
-  width: 100%;
-  height: 100%;
-  background-color: black;
-  opacity: 0.4;
-  top: 0;
-  display: none;
+.pixel-art-react-container {
+  .simple-spinner {
+    position: absolute;
+    z-index: 1;
+    left: 0;
+    right: 0;
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
+    height: 100%;
+    background-color: black;
+    opacity: 0.4;
+    top: 0;
+    display: none;
 
-  &.display {
-    display: block;
+    &.display {
+      display: block;
+    }
+
+    .circle {
+      height: 60px;
+      width: 60px;
+      margin: 94px auto 0;
+      position: fixed;
+      animation: spin-rotation 0.6s infinite linear;
+      border-left: 6px solid rgba(239, 149, 50, 0.35);
+      border-right: 6px solid rgba(239, 149, 50, 0.35);
+      border-bottom: 6px solid rgba(239, 149, 50, 0.35);
+      border-top: 6px solid rgba(219, 109, 26, 1);
+      border-radius: 100%;
+      top: 50%;
+      left: 50%;
+      margin-top: -30px;
+      margin-left: -30px;
+    }
   }
 
-  .circle {
-    height: 60px;
-    width: 60px;
-    margin: 94px auto 0;
-    position: fixed;
-    animation: spin-rotation 0.6s infinite linear;
-    border-left: 6px solid rgba(239, 149, 50, 0.35);
-    border-right: 6px solid rgba(239, 149, 50, 0.35);
-    border-bottom: 6px solid rgba(239, 149, 50, 0.35);
-    border-top: 6px solid rgba(219, 109, 26, 1);
-    border-radius: 100%;
-    top: 50%;
-    left: 50%;
-    margin-top: -30px;
-    margin-left: -30px;
-  }
-}
+  @keyframes spin-rotation {
+    from {
+      transform: rotate(0deg);
+    }
 
-@keyframes spin-rotation {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(359deg);
+    to {
+      transform: rotate(359deg);
+    }
   }
 }

--- a/src/css/components/_UndoRedo.css
+++ b/src/css/components/_UndoRedo.css
@@ -1,22 +1,24 @@
-.undo-redo {
-  lost-utility: clearfix;
+.pixel-art-react-container {
+  .undo-redo {
+    lost-utility: clearfix;
 
-  button {
-    @mixin button gray;
+    button {
+      @mixin button gray;
 
-    lost-column: 1/2 0 0.5em;
-    font-size: 1.2em;
-  }
+      lost-column: 1/2 0 0.5em;
+      font-size: 1.2em;
+    }
 
-  .undo-redo__icon--undo {
-    @mixin icon undo;
+    .undo-redo__icon--undo {
+      @mixin icon undo;
 
-    display: block;
-  }
+      display: block;
+    }
 
-  .undo-redo__icon--redo {
-    @mixin icon redo;
+    .undo-redo__icon--redo {
+      @mixin icon redo;
 
-    display: block;
+      display: block;
+    }
   }
 }

--- a/src/css/components/_UsefulData.css
+++ b/src/css/components/_UsefulData.css
@@ -1,56 +1,58 @@
-.useful-data {
-  text-align: center;
-  .useful-data__rows {
-    border: none;
-    background-color: $color-alto;
-    padding: 1em 0;
-    .checkbox {
-      padding: 0.4em 0;
-    }
-  }
-  .useful-data__export {
-    font-family: $font-monospace;
-    overflow-x: hidden;
-    margin: 1em auto;
-    background-color: $color-mineShaft;
-    color: $color-silver;
-    padding: 0.5em;
-    text-align: left;
-    display: block;
-    width: 100%;
-    resize: none;
-    height: 20em;
-  }
-  .useful-data__options {
-    lost-utility: clearfix;
-    fieldset.useful-data__rows,
-    .useful-data__output {
-      lost-column: 1/2 0 0;
-    }
-    fieldset.useful-data__rows {
-      lost-utility: clearfix;
-      margin: 0;
-      height: 20em;
-      .useful-data__pixel-format,
-      .useful-data__reverse-rows {
-        lost-column: 1/2 0 0;
+.pixel-art-react-container {
+  .useful-data {
+    text-align: center;
+    .useful-data__rows {
+      border: none;
+      background-color: $color-alto;
+      padding: 1em 0;
+      .checkbox {
+        padding: 0.4em 0;
       }
     }
-  }
-}
-
-@media only screen and (max-width: 730px) {
-  .useful-data {
+    .useful-data__export {
+      font-family: $font-monospace;
+      overflow-x: hidden;
+      margin: 1em auto;
+      background-color: $color-mineShaft;
+      color: $color-silver;
+      padding: 0.5em;
+      text-align: left;
+      display: block;
+      width: 100%;
+      resize: none;
+      height: 20em;
+    }
     .useful-data__options {
+      lost-utility: clearfix;
       fieldset.useful-data__rows,
       .useful-data__output {
-        lost-column: 1/1;
+        lost-column: 1/2 0 0;
       }
       fieldset.useful-data__rows {
-        height: auto;
+        lost-utility: clearfix;
+        margin: 0;
+        height: 20em;
         .useful-data__pixel-format,
         .useful-data__reverse-rows {
+          lost-column: 1/2 0 0;
+        }
+      }
+    }
+  }
+
+  @media only screen and (max-width: 730px) {
+    .useful-data {
+      .useful-data__options {
+        fieldset.useful-data__rows,
+        .useful-data__output {
           lost-column: 1/1;
+        }
+        fieldset.useful-data__rows {
+          height: auto;
+          .useful-data__pixel-format,
+          .useful-data__reverse-rows {
+            lost-column: 1/1;
+          }
         }
       }
     }

--- a/src/css/fonts/_fonts.css
+++ b/src/css/fonts/_fonts.css
@@ -98,6 +98,8 @@
   content: '\74';
 }
 
-.icon-help {
-  @mixin icon help;
+.pixel-art-react-container {
+  .icon-help {
+    @mixin icon help;
+  }
 }

--- a/src/css/input/_button.css
+++ b/src/css/input/_button.css
@@ -1,62 +1,65 @@
-@define-mixin generate-button $color-text, $color-bg, $color-boxshadow,
-  $color-bg-active {
-  background: none;
-  border: none;
-  outline: none;
-  border-radius: 2px;
-  padding: 10px;
-  font-size: 1em;
-  text-decoration: none;
-  transition-duration: 0.1s;
-  color: $color-text;
-  background-color: $color-bg;
-  box-shadow: 0 5px 0 0 $color-boxshadow;
+.pixel-art-react-container {
+  @define-mixin generate-button $color-text, $color-bg, $color-boxshadow,
+    $color-bg-active {
+    background: none;
+    border: none;
+    outline: none;
+    border-radius: 2px;
+    padding: 10px;
+    font-size: 1em;
+    text-decoration: none;
+    transition-duration: 0.1s;
+    color: $color-text;
+    background-color: $color-bg;
+    box-shadow: 0 5px 0 0 $color-boxshadow;
 
-  &:hover,
-  &.selected {
-    background-color: $color-bg-active;
+    &:hover,
+    &.selected {
+      background-color: $color-bg-active;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:active {
+      transform: translate(0, 5px);
+      box-shadow: 0 1px 0 $color-bg-active;
+      background-color: $color-bg-active;
+    }
   }
 
-  &:hover {
-    cursor: pointer;
-  }
+  @define-mixin button $color, $font: $font-pixel {
+    @if $color == red {
+      @mixin generate-button $color-silver, $color-tamarillo, $color-darkTan,
+        $color-moccaccino;
+    }
 
-  &:active {
-    transform: translate(0, 5px);
-    box-shadow: 0 1px 0 $color-bg-active;
-    background-color: $color-bg-active;
-  }
-}
+    @if $color == gray {
+      @mixin generate-button $color-silver, $color-mineShaft, $color-doveGray,
+        $color-tundora;
+    }
 
-@define-mixin button $color, $font: $font-pixel {
-  @if $color == red {
-    @mixin generate-button $color-silver, $color-tamarillo, $color-darkTan,
-      $color-moccaccino;
-  }
+    @if $color == brown {
+      @mixin generate-button $color-silver, $color-lotus, $color-buccaneer,
+        $color-cowboy;
+    }
 
-  @if $color == gray {
-    @mixin generate-button $color-silver, $color-mineShaft, $color-doveGray,
-      $color-tundora;
-  }
+    @if $color == blue {
+      @mixin generate-button $color-silver, $color-steelblue, $color-sanMarino,
+        $color-eastBay;
+    }
 
-  @if $color == brown {
-    @mixin generate-button $color-silver, $color-lotus, $color-buccaneer,
-      $color-cowboy;
-  }
+    @if $color == darkblue {
+      @mixin generate-button $color-silver, $color-chathamsBlue, $color-chambray,
+        $color-cloudBurst;
+    }
 
-  @if $color == blue {
-    @mixin generate-button $color-silver, $color-steelblue, $color-sanMarino,
-      $color-eastBay;
-  }
+    @if $color == white {
+      @mixin generate-button black, $color-alto, $color-silveChalice,
+        $color-nobel;
+    }
 
-  @if $color == darkblue {
-    @mixin generate-button $color-silver, $color-chathamsBlue, $color-chambray,
-      $color-cloudBurst;
+    font-family: $font;
   }
-
-  @if $color == white {
-    @mixin generate-button black, $color-alto, $color-silveChalice, $color-nobel;
-  }
-
-  font-family: $font;
 }

--- a/src/css/input/_inputText.css
+++ b/src/css/input/_inputText.css
@@ -1,32 +1,34 @@
-@define-mixin inputText {
-  appearance: none;
-  box-shadow: none;
-  border-radius: none;
-  text-align: center;
-  font-size: 1em;
-  color: $color-silver;
-  border: none;
-  width: 100%;
-  background-color: $color-tundora;
-  transition: background-color 0.3s;
+.pixel-art-react-container {
+  @define-mixin inputText {
+    appearance: none;
+    box-shadow: none;
+    border-radius: none;
+    text-align: center;
+    font-size: 1em;
+    color: $color-silver;
+    border: none;
+    width: 100%;
+    background-color: $color-tundora;
+    transition: background-color 0.3s;
 
-  &:focus {
-    color: $color-mineShaft;
-    background-color: $color-dustyGray;
-    outline: none;
+    &:focus {
+      color: $color-mineShaft;
+      background-color: $color-dustyGray;
+      outline: none;
+    }
   }
-}
 
-input[type='text'],
-input[type='number'] {
-  @mixin inputText;
-}
+  input[type='text'],
+  input[type='number'] {
+    @mixin inputText;
+  }
 
-input[type='number'] {
-  -moz-appearance: textfield;
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
+  input[type='number'] {
+    -moz-appearance: textfield;
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
   }
 }

--- a/src/css/layout/_flex.css
+++ b/src/css/layout/_flex.css
@@ -1,5 +1,7 @@
-@define-mixin flex-row-center {
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: center;
+.pixel-art-react-container {
+  @define-mixin flex-row-center {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+  }
 }

--- a/src/css/layout/_grid.css
+++ b/src/css/layout/_grid.css
@@ -1,69 +1,71 @@
-.clearfix {
-  lost-utility: clearfix;
-}
-
-.col-1-3 {
-  lost-column: 1/3;
-}
-
-.col-2-3 {
-  lost-column: 2/3;
-}
-
-.col-1-2 {
-  lost-column: 1/2;
-}
-
-.col-1-4 {
-  lost-column: 1/4;
-}
-
-.col-2-4 {
-  lost-column: 2/4;
-}
-
-.col-3-4,
-.col-6-8 {
-  lost-column: 3/4;
-}
-
-.col-1-8 {
-  lost-column: 1/8;
-}
-
-.col-7-8 {
-  lost-column: 7/8;
-}
-
-.grid-3 {
-  lost-utility: clearfix;
-
-  & > div {
-    lost-column: 1/3 3 0;
+.pixel-art-react-container {
+  .clearfix {
+    lost-utility: clearfix;
   }
-}
 
-.grid-4 {
-  lost-utility: clearfix;
-
-  & > div {
-    lost-column: 1/4 4 0;
+  .col-1-3 {
+    lost-column: 1/3;
   }
-}
 
-.grid-2 {
-  lost-utility: clearfix;
-
-  & > div {
-    lost-column: 1/2 2 0;
+  .col-2-3 {
+    lost-column: 2/3;
   }
-}
 
-.max-width-container {
-  max-width: $max-width-container;
-}
+  .col-1-2 {
+    lost-column: 1/2;
+  }
 
-.max-width-container-centered {
-  max-width: $max-width-container;
-  margin: 0 auto;
+  .col-1-4 {
+    lost-column: 1/4;
+  }
+
+  .col-2-4 {
+    lost-column: 2/4;
+  }
+
+  .col-3-4,
+  .col-6-8 {
+    lost-column: 3/4;
+  }
+
+  .col-1-8 {
+    lost-column: 1/8;
+  }
+
+  .col-7-8 {
+    lost-column: 7/8;
+  }
+
+  .grid-3 {
+    lost-utility: clearfix;
+
+    & > div {
+      lost-column: 1/3 3 0;
+    }
+  }
+
+  .grid-4 {
+    lost-utility: clearfix;
+
+    & > div {
+      lost-column: 1/4 4 0;
+    }
+  }
+
+  .grid-2 {
+    lost-utility: clearfix;
+
+    & > div {
+      lost-column: 1/2 2 0;
+    }
+  }
+
+  .max-width-container {
+    max-width: $max-width-container;
+  }
+
+  .max-width-container-centered {
+    max-width: $max-width-container;
+    margin: 0 auto;
+  }
 }

--- a/src/css/layout/_header.css
+++ b/src/css/layout/_header.css
@@ -1,61 +1,63 @@
-header {
-  color: $color-silver;
-  lost-utility: clearfix;
-  margin: 1em 0;
-  a {
-    text-decoration: none;
-    color: inherit;
-    &:visited,
-    &:hover,
-    &:active {
+.pixel-art-react-container {
+  header {
+    color: $color-silver;
+    lost-utility: clearfix;
+    margin: 1em 0;
+    a {
+      text-decoration: none;
       color: inherit;
+      &:visited,
+      &:hover,
+      &:active {
+        color: inherit;
+      }
     }
-  }
-  h1 {
-    margin: 0;
-  }
+    h1 {
+      margin: 0;
+    }
 
-  .header__social {
-    text-align: right;
+    .header__social {
+      text-align: right;
 
-    .header__credits {
-      font-size: 12px;
-      margin-bottom: 0.2em;
+      .header__credits {
+        font-size: 12px;
+        margin-bottom: 0.2em;
 
-      a {
-        color: $color-silver;
-      }
+        a {
+          color: $color-silver;
+        }
 
-      span {
-        color: $color-brandyRose;
-      }
+        span {
+          color: $color-brandyRose;
+        }
 
-      h2 {
-        display: block;
-        font-size: 0.8em;
-        padding-right: 1.3em;
-        position: relative;
-        margin: 0;
-        top: 0;
-      }
+        h2 {
+          display: block;
+          font-size: 0.8em;
+          padding-right: 1.3em;
+          position: relative;
+          margin: 0;
+          top: 0;
+        }
 
-      &:hover {
-        img {
-          transform: scale(1.2);
+        &:hover {
+          img {
+            transform: scale(1.2);
+          }
         }
       }
     }
   }
-}
 
-@media only screen and (max-width: 460px) {
-  header {
-    .col-2-3,
-    .col-1-3 {
-      lost-column: 1/2;
+  @media only screen and (max-width: 460px) {
+    header {
+      .col-2-3,
+      .col-1-3 {
+        lost-column: 1/2;
+      }
     }
-  }
-  h1 {
-    font-size: 1.5em;
+    h1 {
+      font-size: 1.5em;
+    }
   }
 }

--- a/src/css/layout/_queries.css
+++ b/src/css/layout/_queries.css
@@ -1,118 +1,120 @@
-@media only screen and (max-width: 1250px) {
-  .app__left-side,
-  .app__right-side {
-    width: 100% !important;
-  }
-}
-
-@media only screen and (max-width: 780px) {
-  .dimensions {
-    label {
-      font-size: 1.5em !important;
-      top: -0.2em;
+.pixel-art-react-container {
+  @media only screen and (max-width: 1250px) {
+    .app__left-side,
+    .app__right-side {
+      width: 100% !important;
     }
   }
-}
 
-@media only screen and (min-width: 730px) {
-  /*
+  @media only screen and (max-width: 780px) {
+    .dimensions {
+      label {
+        font-size: 1.5em !important;
+        top: -0.2em;
+      }
+    }
+  }
+
+  @media only screen and (min-width: 730px) {
+    /*
     Fix small vertical scrollbar glitch for some resolutions
     inside frames-handler
     Detected in Chrome
   */
-  .app__frames-container::-webkit-scrollbar,
-  .app__frames-container div::-webkit-scrollbar {
-    width: 1em !important;
-  }
-}
-
-@media only screen and (max-width: 730px) {
-  .app__copycss-button {
-    margin-top: 1.4em !important;
+    .app__frames-container::-webkit-scrollbar,
+    .app__frames-container div::-webkit-scrollbar {
+      width: 1em !important;
+    }
   }
 
-  .app__central-container {
-    .col-1-4 {
-      &.left {
-        lost-column: none;
+  @media only screen and (max-width: 730px) {
+    .app__copycss-button {
+      margin-top: 1.4em !important;
+    }
 
-        .app__copycss-button {
-          padding: 4px !important;
+    .app__central-container {
+      .col-1-4 {
+        &.left {
+          lost-column: none;
+
+          .app__copycss-button {
+            padding: 4px !important;
+          }
+
+          .palette-grid {
+            margin: 0;
+          }
         }
 
-        .palette-grid {
-          margin: 0;
+        &.right {
+          lost-column: none;
         }
       }
 
-      &.right {
-        lost-column: none;
-      }
-    }
+      .col-2-4 {
+        &.center {
+          lost-column: none;
 
-    .col-2-4 {
-      &.center {
-        lost-column: none;
-
-        .grid-container {
-          margin: 1em auto !important;
+          .grid-container {
+            margin: 1em auto !important;
+          }
         }
       }
     }
-  }
 
-  .app__mobile--container {
-    lost-utility: clearfix;
+    .app__mobile--container {
+      lost-utility: clearfix;
 
-    .app__mobile--group {
-      lost-column: 1/2;
+      .app__mobile--group {
+        lost-column: 1/2;
+      }
+
+      max-width: none;
     }
 
-    max-width: none;
-  }
+    .app__preview-button {
+      margin-top: 1em !important;
+    }
 
-  .app__preview-button {
-    margin-top: 1em !important;
-  }
+    body {
+      width: 100% !important;
+    }
 
-  body {
-    width: 100% !important;
-  }
+    /* Avoid button hover effect in mobile devices */
+    .undo-redo,
+    .app__load-save-container,
+    .new-project,
+    .frames-handler,
+    .app__right-side {
+      button:hover,
+      button.selected {
+        background-color: $color-mineShaft !important;
+      }
+    }
 
-  /* Avoid button hover effect in mobile devices */
-  .undo-redo,
-  .app__load-save-container,
-  .new-project,
-  .frames-handler,
-  .app__right-side {
-    button:hover,
-    button.selected {
-      background-color: $color-mineShaft !important;
+    button.app__copycss-button {
+      &:hover,
+      &.selected {
+        background-color: $color-alto !important;
+      }
+    }
+
+    .app__toggle-help-button {
+      &:hover,
+      &.selected {
+        background-color: $color-chathamsBlue !important;
+      }
+    }
+
+    .load-drawing__import {
+      height: 10em !important;
     }
   }
 
-  button.app__copycss-button {
-    &:hover,
-    &.selected {
-      background-color: $color-alto !important;
+  @media only screen and (max-width: 360px) {
+    button,
+    .dimensions {
+      font-size: 0.8em !important;
     }
-  }
-
-  .app__toggle-help-button {
-    &:hover,
-    &.selected {
-      background-color: $color-chathamsBlue !important;
-    }
-  }
-
-  .load-drawing__import {
-    height: 10em !important;
-  }
-}
-
-@media only screen and (max-width: 360px) {
-  button,
-  .dimensions {
-    font-size: 0.8em !important;
   }
 }

--- a/src/css/views/_cookies.css
+++ b/src/css/views/_cookies.css
@@ -1,129 +1,131 @@
-.cookies-disclaimer {
-  padding: 2em;
-  text-align: left;
-  color: $color-silver;
-  width: 50%;
-  margin: 0 auto;
-  h2 {
-    font-size: 2.5em;
-    top: 0;
-    margin: 1em 0 1.5em 0;
-    display: block;
-    text-align: center;
-    padding: 0;
-  }
-  h3 {
-    font-size: 1.5em;
-  }
-  a {
-    text-decoration: none;
-    color: #78b4ff;
-  }
-  li {
-    list-style-type: none;
-  }
-  ul li:before {
-    content: '•';
-    font-size: 100%;
-    padding-right: 10px;
-  }
-  .art-wrapper {
-    height: 100px;
-    width: 100px;
-    margin: 1em auto;
-  }
-  .pixelart-cookie {
-    box-shadow: 40px 10px 0 #ac7d40, 50px 10px 0 #ac7d40, 60px 10px 0 #332413,
-      70px 10px 0 #eea64b, 30px 20px 0 #ac7d40, 40px 20px 0 #eea64b,
-      50px 20px 0 #eea64b, 60px 20px 0 #eea64b, 70px 20px 0 #eea64b,
-      80px 20px 0 #ac7d40, 20px 30px 0 #ac7d40, 30px 30px 0 #332413,
-      40px 30px 0 #eea64b, 50px 30px 0 #eea64b, 60px 30px 0 #eea64b,
-      70px 30px 0 #332413, 80px 30px 0 #332413, 90px 30px 0 #eea64b,
-      20px 40px 0 #eea64b, 30px 40px 0 #eea64b, 40px 40px 0 #eea64b,
-      50px 40px 0 #332413, 60px 40px 0 #eea64b, 70px 40px 0 #332413,
-      80px 40px 0 #332413, 90px 40px 0 #eea64b, 10px 50px 0 #ac7d40,
-      20px 50px 0 #332413, 30px 50px 0 #eea64b, 40px 50px 0 #eea64b,
-      50px 50px 0 #eea64b, 60px 50px 0 #eea64b, 70px 50px 0 #eea64b,
-      80px 50px 0 #eea64b, 90px 50px 0 #eea64b, 100px 50px 0 #ac7d40,
-      10px 60px 0 #ac7d40, 20px 60px 0 #eea64b, 30px 60px 0 #eea64b,
-      40px 60px 0 #332413, 50px 60px 0 #eea64b, 60px 60px 0 #eea64b,
-      70px 60px 0 #eea64b, 80px 60px 0 #eea64b, 90px 60px 0 #332413,
-      100px 60px 0 #ac7d40, 10px 70px 0 #9a4719, 20px 70px 0 #332413,
-      30px 70px 0 #eea64b, 40px 70px 0 #eea64b, 50px 70px 0 #eea64b,
-      60px 70px 0 #332413, 70px 70px 0 #eea64b, 80px 70px 0 #dc9736,
-      90px 70px 0 #dc9736, 100px 70px 0 #9a4719, 20px 80px 0 #9a4719,
-      30px 80px 0 #dc9736, 40px 80px 0 #dc9736, 50px 80px 0 #dc9736,
-      60px 80px 0 #dc9736, 70px 80px 0 #dc9736, 80px 80px 0 #dc9736,
-      90px 80px 0 #9a4719, 30px 90px 0 #9a4719, 40px 90px 0 #dc9736,
-      50px 90px 0 #dc9736, 60px 90px 0 #dc9736, 70px 90px 0 #332413,
-      80px 90px 0 #9a4719, 40px 100px 0 #9a4719, 50px 100px 0 #9a4719,
-      60px 100px 0 #9a4719, 70px 100px 0 #9a4719;
-    -webkit-box-shadow: 40px 10px 0 #ac7d40, 50px 10px 0 #ac7d40,
-      60px 10px 0 #332413, 70px 10px 0 #eea64b, 30px 20px 0 #ac7d40,
-      40px 20px 0 #eea64b, 50px 20px 0 #eea64b, 60px 20px 0 #eea64b,
-      70px 20px 0 #eea64b, 80px 20px 0 #ac7d40, 20px 30px 0 #ac7d40,
-      30px 30px 0 #332413, 40px 30px 0 #eea64b, 50px 30px 0 #eea64b,
-      60px 30px 0 #eea64b, 70px 30px 0 #332413, 80px 30px 0 #332413,
-      90px 30px 0 #eea64b, 20px 40px 0 #eea64b, 30px 40px 0 #eea64b,
-      40px 40px 0 #eea64b, 50px 40px 0 #332413, 60px 40px 0 #eea64b,
-      70px 40px 0 #332413, 80px 40px 0 #332413, 90px 40px 0 #eea64b,
-      10px 50px 0 #ac7d40, 20px 50px 0 #332413, 30px 50px 0 #eea64b,
-      40px 50px 0 #eea64b, 50px 50px 0 #eea64b, 60px 50px 0 #eea64b,
-      70px 50px 0 #eea64b, 80px 50px 0 #eea64b, 90px 50px 0 #eea64b,
-      100px 50px 0 #ac7d40, 10px 60px 0 #ac7d40, 20px 60px 0 #eea64b,
-      30px 60px 0 #eea64b, 40px 60px 0 #332413, 50px 60px 0 #eea64b,
-      60px 60px 0 #eea64b, 70px 60px 0 #eea64b, 80px 60px 0 #eea64b,
-      90px 60px 0 #332413, 100px 60px 0 #ac7d40, 10px 70px 0 #9a4719,
-      20px 70px 0 #332413, 30px 70px 0 #eea64b, 40px 70px 0 #eea64b,
-      50px 70px 0 #eea64b, 60px 70px 0 #332413, 70px 70px 0 #eea64b,
-      80px 70px 0 #dc9736, 90px 70px 0 #dc9736, 100px 70px 0 #9a4719,
-      20px 80px 0 #9a4719, 30px 80px 0 #dc9736, 40px 80px 0 #dc9736,
-      50px 80px 0 #dc9736, 60px 80px 0 #dc9736, 70px 80px 0 #dc9736,
-      80px 80px 0 #dc9736, 90px 80px 0 #9a4719, 30px 90px 0 #9a4719,
-      40px 90px 0 #dc9736, 50px 90px 0 #dc9736, 60px 90px 0 #dc9736,
-      70px 90px 0 #332413, 80px 90px 0 #9a4719, 40px 100px 0 #9a4719,
-      50px 100px 0 #9a4719, 60px 100px 0 #9a4719, 70px 100px 0 #9a4719;
-    -moz-box-shadow: 40px 10px 0 #ac7d40, 50px 10px 0 #ac7d40,
-      60px 10px 0 #332413, 70px 10px 0 #eea64b, 30px 20px 0 #ac7d40,
-      40px 20px 0 #eea64b, 50px 20px 0 #eea64b, 60px 20px 0 #eea64b,
-      70px 20px 0 #eea64b, 80px 20px 0 #ac7d40, 20px 30px 0 #ac7d40,
-      30px 30px 0 #332413, 40px 30px 0 #eea64b, 50px 30px 0 #eea64b,
-      60px 30px 0 #eea64b, 70px 30px 0 #332413, 80px 30px 0 #332413,
-      90px 30px 0 #eea64b, 20px 40px 0 #eea64b, 30px 40px 0 #eea64b,
-      40px 40px 0 #eea64b, 50px 40px 0 #332413, 60px 40px 0 #eea64b,
-      70px 40px 0 #332413, 80px 40px 0 #332413, 90px 40px 0 #eea64b,
-      10px 50px 0 #ac7d40, 20px 50px 0 #332413, 30px 50px 0 #eea64b,
-      40px 50px 0 #eea64b, 50px 50px 0 #eea64b, 60px 50px 0 #eea64b,
-      70px 50px 0 #eea64b, 80px 50px 0 #eea64b, 90px 50px 0 #eea64b,
-      100px 50px 0 #ac7d40, 10px 60px 0 #ac7d40, 20px 60px 0 #eea64b,
-      30px 60px 0 #eea64b, 40px 60px 0 #332413, 50px 60px 0 #eea64b,
-      60px 60px 0 #eea64b, 70px 60px 0 #eea64b, 80px 60px 0 #eea64b,
-      90px 60px 0 #332413, 100px 60px 0 #ac7d40, 10px 70px 0 #9a4719,
-      20px 70px 0 #332413, 30px 70px 0 #eea64b, 40px 70px 0 #eea64b,
-      50px 70px 0 #eea64b, 60px 70px 0 #332413, 70px 70px 0 #eea64b,
-      80px 70px 0 #dc9736, 90px 70px 0 #dc9736, 100px 70px 0 #9a4719,
-      20px 80px 0 #9a4719, 30px 80px 0 #dc9736, 40px 80px 0 #dc9736,
-      50px 80px 0 #dc9736, 60px 80px 0 #dc9736, 70px 80px 0 #dc9736,
-      80px 80px 0 #dc9736, 90px 80px 0 #9a4719, 30px 90px 0 #9a4719,
-      40px 90px 0 #dc9736, 50px 90px 0 #dc9736, 60px 90px 0 #dc9736,
-      70px 90px 0 #332413, 80px 90px 0 #9a4719, 40px 100px 0 #9a4719,
-      50px 100px 0 #9a4719, 60px 100px 0 #9a4719, 70px 100px 0 #9a4719;
-    height: 10px;
-    width: 10px;
-  }
-  span.highlight {
-    color: $color-brandyRose;
-  }
-}
-
-@media only screen and (max-width: 1200px) {
+.pixel-art-react-container {
   .cookies-disclaimer {
-    width: 80%;
+    padding: 2em;
+    text-align: left;
+    color: $color-silver;
+    width: 50%;
+    margin: 0 auto;
+    h2 {
+      font-size: 2.5em;
+      top: 0;
+      margin: 1em 0 1.5em 0;
+      display: block;
+      text-align: center;
+      padding: 0;
+    }
+    h3 {
+      font-size: 1.5em;
+    }
+    a {
+      text-decoration: none;
+      color: #78b4ff;
+    }
+    li {
+      list-style-type: none;
+    }
+    ul li:before {
+      content: '•';
+      font-size: 100%;
+      padding-right: 10px;
+    }
+    .art-wrapper {
+      height: 100px;
+      width: 100px;
+      margin: 1em auto;
+    }
+    .pixelart-cookie {
+      box-shadow: 40px 10px 0 #ac7d40, 50px 10px 0 #ac7d40, 60px 10px 0 #332413,
+        70px 10px 0 #eea64b, 30px 20px 0 #ac7d40, 40px 20px 0 #eea64b,
+        50px 20px 0 #eea64b, 60px 20px 0 #eea64b, 70px 20px 0 #eea64b,
+        80px 20px 0 #ac7d40, 20px 30px 0 #ac7d40, 30px 30px 0 #332413,
+        40px 30px 0 #eea64b, 50px 30px 0 #eea64b, 60px 30px 0 #eea64b,
+        70px 30px 0 #332413, 80px 30px 0 #332413, 90px 30px 0 #eea64b,
+        20px 40px 0 #eea64b, 30px 40px 0 #eea64b, 40px 40px 0 #eea64b,
+        50px 40px 0 #332413, 60px 40px 0 #eea64b, 70px 40px 0 #332413,
+        80px 40px 0 #332413, 90px 40px 0 #eea64b, 10px 50px 0 #ac7d40,
+        20px 50px 0 #332413, 30px 50px 0 #eea64b, 40px 50px 0 #eea64b,
+        50px 50px 0 #eea64b, 60px 50px 0 #eea64b, 70px 50px 0 #eea64b,
+        80px 50px 0 #eea64b, 90px 50px 0 #eea64b, 100px 50px 0 #ac7d40,
+        10px 60px 0 #ac7d40, 20px 60px 0 #eea64b, 30px 60px 0 #eea64b,
+        40px 60px 0 #332413, 50px 60px 0 #eea64b, 60px 60px 0 #eea64b,
+        70px 60px 0 #eea64b, 80px 60px 0 #eea64b, 90px 60px 0 #332413,
+        100px 60px 0 #ac7d40, 10px 70px 0 #9a4719, 20px 70px 0 #332413,
+        30px 70px 0 #eea64b, 40px 70px 0 #eea64b, 50px 70px 0 #eea64b,
+        60px 70px 0 #332413, 70px 70px 0 #eea64b, 80px 70px 0 #dc9736,
+        90px 70px 0 #dc9736, 100px 70px 0 #9a4719, 20px 80px 0 #9a4719,
+        30px 80px 0 #dc9736, 40px 80px 0 #dc9736, 50px 80px 0 #dc9736,
+        60px 80px 0 #dc9736, 70px 80px 0 #dc9736, 80px 80px 0 #dc9736,
+        90px 80px 0 #9a4719, 30px 90px 0 #9a4719, 40px 90px 0 #dc9736,
+        50px 90px 0 #dc9736, 60px 90px 0 #dc9736, 70px 90px 0 #332413,
+        80px 90px 0 #9a4719, 40px 100px 0 #9a4719, 50px 100px 0 #9a4719,
+        60px 100px 0 #9a4719, 70px 100px 0 #9a4719;
+      -webkit-box-shadow: 40px 10px 0 #ac7d40, 50px 10px 0 #ac7d40,
+        60px 10px 0 #332413, 70px 10px 0 #eea64b, 30px 20px 0 #ac7d40,
+        40px 20px 0 #eea64b, 50px 20px 0 #eea64b, 60px 20px 0 #eea64b,
+        70px 20px 0 #eea64b, 80px 20px 0 #ac7d40, 20px 30px 0 #ac7d40,
+        30px 30px 0 #332413, 40px 30px 0 #eea64b, 50px 30px 0 #eea64b,
+        60px 30px 0 #eea64b, 70px 30px 0 #332413, 80px 30px 0 #332413,
+        90px 30px 0 #eea64b, 20px 40px 0 #eea64b, 30px 40px 0 #eea64b,
+        40px 40px 0 #eea64b, 50px 40px 0 #332413, 60px 40px 0 #eea64b,
+        70px 40px 0 #332413, 80px 40px 0 #332413, 90px 40px 0 #eea64b,
+        10px 50px 0 #ac7d40, 20px 50px 0 #332413, 30px 50px 0 #eea64b,
+        40px 50px 0 #eea64b, 50px 50px 0 #eea64b, 60px 50px 0 #eea64b,
+        70px 50px 0 #eea64b, 80px 50px 0 #eea64b, 90px 50px 0 #eea64b,
+        100px 50px 0 #ac7d40, 10px 60px 0 #ac7d40, 20px 60px 0 #eea64b,
+        30px 60px 0 #eea64b, 40px 60px 0 #332413, 50px 60px 0 #eea64b,
+        60px 60px 0 #eea64b, 70px 60px 0 #eea64b, 80px 60px 0 #eea64b,
+        90px 60px 0 #332413, 100px 60px 0 #ac7d40, 10px 70px 0 #9a4719,
+        20px 70px 0 #332413, 30px 70px 0 #eea64b, 40px 70px 0 #eea64b,
+        50px 70px 0 #eea64b, 60px 70px 0 #332413, 70px 70px 0 #eea64b,
+        80px 70px 0 #dc9736, 90px 70px 0 #dc9736, 100px 70px 0 #9a4719,
+        20px 80px 0 #9a4719, 30px 80px 0 #dc9736, 40px 80px 0 #dc9736,
+        50px 80px 0 #dc9736, 60px 80px 0 #dc9736, 70px 80px 0 #dc9736,
+        80px 80px 0 #dc9736, 90px 80px 0 #9a4719, 30px 90px 0 #9a4719,
+        40px 90px 0 #dc9736, 50px 90px 0 #dc9736, 60px 90px 0 #dc9736,
+        70px 90px 0 #332413, 80px 90px 0 #9a4719, 40px 100px 0 #9a4719,
+        50px 100px 0 #9a4719, 60px 100px 0 #9a4719, 70px 100px 0 #9a4719;
+      -moz-box-shadow: 40px 10px 0 #ac7d40, 50px 10px 0 #ac7d40,
+        60px 10px 0 #332413, 70px 10px 0 #eea64b, 30px 20px 0 #ac7d40,
+        40px 20px 0 #eea64b, 50px 20px 0 #eea64b, 60px 20px 0 #eea64b,
+        70px 20px 0 #eea64b, 80px 20px 0 #ac7d40, 20px 30px 0 #ac7d40,
+        30px 30px 0 #332413, 40px 30px 0 #eea64b, 50px 30px 0 #eea64b,
+        60px 30px 0 #eea64b, 70px 30px 0 #332413, 80px 30px 0 #332413,
+        90px 30px 0 #eea64b, 20px 40px 0 #eea64b, 30px 40px 0 #eea64b,
+        40px 40px 0 #eea64b, 50px 40px 0 #332413, 60px 40px 0 #eea64b,
+        70px 40px 0 #332413, 80px 40px 0 #332413, 90px 40px 0 #eea64b,
+        10px 50px 0 #ac7d40, 20px 50px 0 #332413, 30px 50px 0 #eea64b,
+        40px 50px 0 #eea64b, 50px 50px 0 #eea64b, 60px 50px 0 #eea64b,
+        70px 50px 0 #eea64b, 80px 50px 0 #eea64b, 90px 50px 0 #eea64b,
+        100px 50px 0 #ac7d40, 10px 60px 0 #ac7d40, 20px 60px 0 #eea64b,
+        30px 60px 0 #eea64b, 40px 60px 0 #332413, 50px 60px 0 #eea64b,
+        60px 60px 0 #eea64b, 70px 60px 0 #eea64b, 80px 60px 0 #eea64b,
+        90px 60px 0 #332413, 100px 60px 0 #ac7d40, 10px 70px 0 #9a4719,
+        20px 70px 0 #332413, 30px 70px 0 #eea64b, 40px 70px 0 #eea64b,
+        50px 70px 0 #eea64b, 60px 70px 0 #332413, 70px 70px 0 #eea64b,
+        80px 70px 0 #dc9736, 90px 70px 0 #dc9736, 100px 70px 0 #9a4719,
+        20px 80px 0 #9a4719, 30px 80px 0 #dc9736, 40px 80px 0 #dc9736,
+        50px 80px 0 #dc9736, 60px 80px 0 #dc9736, 70px 80px 0 #dc9736,
+        80px 80px 0 #dc9736, 90px 80px 0 #9a4719, 30px 90px 0 #9a4719,
+        40px 90px 0 #dc9736, 50px 90px 0 #dc9736, 60px 90px 0 #dc9736,
+        70px 90px 0 #332413, 80px 90px 0 #9a4719, 40px 100px 0 #9a4719,
+        50px 100px 0 #9a4719, 60px 100px 0 #9a4719, 70px 100px 0 #9a4719;
+      height: 10px;
+      width: 10px;
+    }
+    span.highlight {
+      color: $color-brandyRose;
+    }
   }
-}
 
-@media only screen and (max-width: 700px) {
-  .cookies-disclaimer {
-    width: 90%;
+  @media only screen and (max-width: 1200px) {
+    .cookies-disclaimer {
+      width: 80%;
+    }
+  }
+
+  @media only screen and (max-width: 700px) {
+    .cookies-disclaimer {
+      width: 90%;
+    }
   }
 }

--- a/src/css/views/_notFound.css
+++ b/src/css/views/_notFound.css
@@ -1,157 +1,173 @@
-.not-found {
-  text-align: center;
-  h2 {
-    font-size: 2.5em;
-    top: 0;
-    margin: 1em 0 1em 0;
-    display: block;
+.pixel-art-react-container {
+  .not-found {
     text-align: center;
-    padding: 0;
-    color: $color-brandyRose;
-  }
-  a {
-    color: #78b4ff;
-  }
-  .art-wrapper {
-    height: 100px;
-    width: 320px;
-    margin: 1em auto 9em;
+    h2 {
+      font-size: 2.5em;
+      top: 0;
+      margin: 1em 0 1em 0;
+      display: block;
+      text-align: center;
+      padding: 0;
+      color: $color-brandyRose;
+    }
+    a {
+      color: #78b4ff;
+    }
+    .art-wrapper {
+      height: 100px;
+      width: 320px;
+      margin: 1em auto 9em;
+    }
+
+    .pixelart-notfound {
+      position: absolute;
+      animation: notfound 1s infinite;
+      -webkit-animation: notfound 1s infinite;
+      -moz-animation: notfound 1s infinite;
+      -o-animation: notfound 1s infinite;
+    }
   }
 
-  .pixelart-notfound {
-    position: absolute;
-    animation: notfound 1s infinite;
-    -webkit-animation: notfound 1s infinite;
-    -moz-animation: notfound 1s infinite;
-    -o-animation: notfound 1s infinite;
-  }
-}
-
-@keyframes notfound {
-  0%,
-  25% {
-    box-shadow: 20px 40px 0 0 rgba(187, 187, 187, 1),
-      80px 40px 0 0 rgba(187, 187, 187, 1),
-      140px 40px 0 0 rgba(187, 187, 187, 1),
-      160px 40px 0 0 rgba(187, 187, 187, 1),
-      220px 40px 0 0 rgba(187, 187, 187, 1),
-      280px 40px 0 0 rgba(187, 187, 187, 1),
-      20px 60px 0 0 rgba(187, 187, 187, 1), 80px 60px 0 0 rgba(187, 187, 187, 1),
-      120px 60px 0 0 rgba(187, 187, 187, 1),
-      180px 60px 0 0 rgba(187, 187, 187, 1),
-      220px 60px 0 0 rgba(187, 187, 187, 1),
-      280px 60px 0 0 rgba(187, 187, 187, 1),
-      20px 80px 0 0 rgba(187, 187, 187, 1), 40px 80px 0 0 rgba(187, 187, 187, 1),
-      60px 80px 0 0 rgba(187, 187, 187, 1), 80px 80px 0 0 rgba(187, 187, 187, 1),
-      120px 80px 0 0 rgba(187, 187, 187, 1),
-      180px 80px 0 0 rgba(187, 187, 187, 1),
-      220px 80px 0 0 rgba(187, 187, 187, 1),
-      240px 80px 0 0 rgba(187, 187, 187, 1),
-      260px 80px 0 0 rgba(187, 187, 187, 1),
-      280px 80px 0 0 rgba(187, 187, 187, 1),
-      80px 100px 0 0 rgba(187, 187, 187, 1),
-      120px 100px 0 0 rgba(187, 187, 187, 1),
-      180px 100px 0 0 rgba(187, 187, 187, 1),
-      280px 100px 0 0 rgba(187, 187, 187, 1),
-      80px 120px 0 0 rgba(187, 187, 187, 1),
-      140px 120px 0 0 rgba(187, 187, 187, 1),
-      160px 120px 0 0 rgba(187, 187, 187, 1),
-      280px 120px 0 0 rgba(187, 187, 187, 1);
-    height: 20px;
-    width: 20px;
-  }
-  25.01%,
-  50% {
-    box-shadow: 20px 20px 0 0 rgba(187, 187, 187, 1),
-      80px 20px 0 0 rgba(187, 187, 187, 1), 20px 40px 0 0 rgba(187, 187, 187, 1),
-      80px 40px 0 0 rgba(187, 187, 187, 1),
-      140px 40px 0 0 rgba(187, 187, 187, 1),
-      160px 40px 0 0 rgba(187, 187, 187, 1),
-      220px 40px 0 0 rgba(187, 187, 187, 1),
-      280px 40px 0 0 rgba(187, 187, 187, 1),
-      20px 60px 0 0 rgba(187, 187, 187, 1), 40px 60px 0 0 rgba(187, 187, 187, 1),
-      60px 60px 0 0 rgba(187, 187, 187, 1), 80px 60px 0 0 rgba(187, 187, 187, 1),
-      120px 60px 0 0 rgba(187, 187, 187, 1),
-      180px 60px 0 0 rgba(187, 187, 187, 1),
-      220px 60px 0 0 rgba(187, 187, 187, 1),
-      280px 60px 0 0 rgba(187, 187, 187, 1),
-      80px 80px 0 0 rgba(187, 187, 187, 1),
-      120px 80px 0 0 rgba(187, 187, 187, 1),
-      180px 80px 0 0 rgba(187, 187, 187, 1),
-      220px 80px 0 0 rgba(187, 187, 187, 1),
-      240px 80px 0 0 rgba(187, 187, 187, 1),
-      260px 80px 0 0 rgba(187, 187, 187, 1),
-      280px 80px 0 0 rgba(187, 187, 187, 1),
-      80px 100px 0 0 rgba(187, 187, 187, 1),
-      120px 100px 0 0 rgba(187, 187, 187, 1),
-      180px 100px 0 0 rgba(187, 187, 187, 1),
-      280px 100px 0 0 rgba(187, 187, 187, 1),
-      140px 120px 0 0 rgba(187, 187, 187, 1),
-      160px 120px 0 0 rgba(187, 187, 187, 1),
-      280px 120px 0 0 rgba(187, 187, 187, 1);
-    height: 20px;
-    width: 20px;
-  }
-  50.01%,
-  75% {
-    box-shadow: 140px 20px 0 0 rgba(187, 187, 187, 1),
-      160px 20px 0 0 rgba(187, 187, 187, 1),
-      20px 40px 0 0 rgba(187, 187, 187, 1), 80px 40px 0 0 rgba(187, 187, 187, 1),
-      120px 40px 0 0 rgba(187, 187, 187, 1),
-      180px 40px 0 0 rgba(187, 187, 187, 1),
-      220px 40px 0 0 rgba(187, 187, 187, 1),
-      280px 40px 0 0 rgba(187, 187, 187, 1),
-      20px 60px 0 0 rgba(187, 187, 187, 1), 80px 60px 0 0 rgba(187, 187, 187, 1),
-      120px 60px 0 0 rgba(187, 187, 187, 1),
-      180px 60px 0 0 rgba(187, 187, 187, 1),
-      220px 60px 0 0 rgba(187, 187, 187, 1),
-      280px 60px 0 0 rgba(187, 187, 187, 1),
-      20px 80px 0 0 rgba(187, 187, 187, 1), 40px 80px 0 0 rgba(187, 187, 187, 1),
-      60px 80px 0 0 rgba(187, 187, 187, 1), 80px 80px 0 0 rgba(187, 187, 187, 1),
-      120px 80px 0 0 rgba(187, 187, 187, 1),
-      180px 80px 0 0 rgba(187, 187, 187, 1),
-      220px 80px 0 0 rgba(187, 187, 187, 1),
-      240px 80px 0 0 rgba(187, 187, 187, 1),
-      260px 80px 0 0 rgba(187, 187, 187, 1),
-      280px 80px 0 0 rgba(187, 187, 187, 1),
-      80px 100px 0 0 rgba(187, 187, 187, 1),
-      140px 100px 0 0 rgba(187, 187, 187, 1),
-      160px 100px 0 0 rgba(187, 187, 187, 1),
-      280px 100px 0 0 rgba(187, 187, 187, 1),
-      80px 120px 0 0 rgba(187, 187, 187, 1),
-      280px 120px 0 0 rgba(187, 187, 187, 1);
-    height: 20px;
-    width: 20px;
-  }
-  75.01%,
-  100% {
-    box-shadow: 220px 20px 0 0 rgba(187, 187, 187, 1),
-      280px 20px 0 0 rgba(187, 187, 187, 1),
-      20px 40px 0 0 rgba(187, 187, 187, 1), 80px 40px 0 0 rgba(187, 187, 187, 1),
-      140px 40px 0 0 rgba(187, 187, 187, 1),
-      160px 40px 0 0 rgba(187, 187, 187, 1),
-      220px 40px 0 0 rgba(187, 187, 187, 1),
-      280px 40px 0 0 rgba(187, 187, 187, 1),
-      20px 60px 0 0 rgba(187, 187, 187, 1), 80px 60px 0 0 rgba(187, 187, 187, 1),
-      120px 60px 0 0 rgba(187, 187, 187, 1),
-      180px 60px 0 0 rgba(187, 187, 187, 1),
-      220px 60px 0 0 rgba(187, 187, 187, 1),
-      240px 60px 0 0 rgba(187, 187, 187, 1),
-      260px 60px 0 0 rgba(187, 187, 187, 1),
-      280px 60px 0 0 rgba(187, 187, 187, 1),
-      20px 80px 0 0 rgba(187, 187, 187, 1), 40px 80px 0 0 rgba(187, 187, 187, 1),
-      60px 80px 0 0 rgba(187, 187, 187, 1), 80px 80px 0 0 rgba(187, 187, 187, 1),
-      120px 80px 0 0 rgba(187, 187, 187, 1),
-      180px 80px 0 0 rgba(187, 187, 187, 1),
-      280px 80px 0 0 rgba(187, 187, 187, 1),
-      80px 100px 0 0 rgba(187, 187, 187, 1),
-      120px 100px 0 0 rgba(187, 187, 187, 1),
-      180px 100px 0 0 rgba(187, 187, 187, 1),
-      280px 100px 0 0 rgba(187, 187, 187, 1),
-      80px 120px 0 0 rgba(187, 187, 187, 1),
-      140px 120px 0 0 rgba(187, 187, 187, 1),
-      160px 120px 0 0 rgba(187, 187, 187, 1);
-    height: 20px;
-    width: 20px;
+  @keyframes notfound {
+    0%,
+    25% {
+      box-shadow: 20px 40px 0 0 rgba(187, 187, 187, 1),
+        80px 40px 0 0 rgba(187, 187, 187, 1),
+        140px 40px 0 0 rgba(187, 187, 187, 1),
+        160px 40px 0 0 rgba(187, 187, 187, 1),
+        220px 40px 0 0 rgba(187, 187, 187, 1),
+        280px 40px 0 0 rgba(187, 187, 187, 1),
+        20px 60px 0 0 rgba(187, 187, 187, 1),
+        80px 60px 0 0 rgba(187, 187, 187, 1),
+        120px 60px 0 0 rgba(187, 187, 187, 1),
+        180px 60px 0 0 rgba(187, 187, 187, 1),
+        220px 60px 0 0 rgba(187, 187, 187, 1),
+        280px 60px 0 0 rgba(187, 187, 187, 1),
+        20px 80px 0 0 rgba(187, 187, 187, 1),
+        40px 80px 0 0 rgba(187, 187, 187, 1),
+        60px 80px 0 0 rgba(187, 187, 187, 1),
+        80px 80px 0 0 rgba(187, 187, 187, 1),
+        120px 80px 0 0 rgba(187, 187, 187, 1),
+        180px 80px 0 0 rgba(187, 187, 187, 1),
+        220px 80px 0 0 rgba(187, 187, 187, 1),
+        240px 80px 0 0 rgba(187, 187, 187, 1),
+        260px 80px 0 0 rgba(187, 187, 187, 1),
+        280px 80px 0 0 rgba(187, 187, 187, 1),
+        80px 100px 0 0 rgba(187, 187, 187, 1),
+        120px 100px 0 0 rgba(187, 187, 187, 1),
+        180px 100px 0 0 rgba(187, 187, 187, 1),
+        280px 100px 0 0 rgba(187, 187, 187, 1),
+        80px 120px 0 0 rgba(187, 187, 187, 1),
+        140px 120px 0 0 rgba(187, 187, 187, 1),
+        160px 120px 0 0 rgba(187, 187, 187, 1),
+        280px 120px 0 0 rgba(187, 187, 187, 1);
+      height: 20px;
+      width: 20px;
+    }
+    25.01%,
+    50% {
+      box-shadow: 20px 20px 0 0 rgba(187, 187, 187, 1),
+        80px 20px 0 0 rgba(187, 187, 187, 1),
+        20px 40px 0 0 rgba(187, 187, 187, 1),
+        80px 40px 0 0 rgba(187, 187, 187, 1),
+        140px 40px 0 0 rgba(187, 187, 187, 1),
+        160px 40px 0 0 rgba(187, 187, 187, 1),
+        220px 40px 0 0 rgba(187, 187, 187, 1),
+        280px 40px 0 0 rgba(187, 187, 187, 1),
+        20px 60px 0 0 rgba(187, 187, 187, 1),
+        40px 60px 0 0 rgba(187, 187, 187, 1),
+        60px 60px 0 0 rgba(187, 187, 187, 1),
+        80px 60px 0 0 rgba(187, 187, 187, 1),
+        120px 60px 0 0 rgba(187, 187, 187, 1),
+        180px 60px 0 0 rgba(187, 187, 187, 1),
+        220px 60px 0 0 rgba(187, 187, 187, 1),
+        280px 60px 0 0 rgba(187, 187, 187, 1),
+        80px 80px 0 0 rgba(187, 187, 187, 1),
+        120px 80px 0 0 rgba(187, 187, 187, 1),
+        180px 80px 0 0 rgba(187, 187, 187, 1),
+        220px 80px 0 0 rgba(187, 187, 187, 1),
+        240px 80px 0 0 rgba(187, 187, 187, 1),
+        260px 80px 0 0 rgba(187, 187, 187, 1),
+        280px 80px 0 0 rgba(187, 187, 187, 1),
+        80px 100px 0 0 rgba(187, 187, 187, 1),
+        120px 100px 0 0 rgba(187, 187, 187, 1),
+        180px 100px 0 0 rgba(187, 187, 187, 1),
+        280px 100px 0 0 rgba(187, 187, 187, 1),
+        140px 120px 0 0 rgba(187, 187, 187, 1),
+        160px 120px 0 0 rgba(187, 187, 187, 1),
+        280px 120px 0 0 rgba(187, 187, 187, 1);
+      height: 20px;
+      width: 20px;
+    }
+    50.01%,
+    75% {
+      box-shadow: 140px 20px 0 0 rgba(187, 187, 187, 1),
+        160px 20px 0 0 rgba(187, 187, 187, 1),
+        20px 40px 0 0 rgba(187, 187, 187, 1),
+        80px 40px 0 0 rgba(187, 187, 187, 1),
+        120px 40px 0 0 rgba(187, 187, 187, 1),
+        180px 40px 0 0 rgba(187, 187, 187, 1),
+        220px 40px 0 0 rgba(187, 187, 187, 1),
+        280px 40px 0 0 rgba(187, 187, 187, 1),
+        20px 60px 0 0 rgba(187, 187, 187, 1),
+        80px 60px 0 0 rgba(187, 187, 187, 1),
+        120px 60px 0 0 rgba(187, 187, 187, 1),
+        180px 60px 0 0 rgba(187, 187, 187, 1),
+        220px 60px 0 0 rgba(187, 187, 187, 1),
+        280px 60px 0 0 rgba(187, 187, 187, 1),
+        20px 80px 0 0 rgba(187, 187, 187, 1),
+        40px 80px 0 0 rgba(187, 187, 187, 1),
+        60px 80px 0 0 rgba(187, 187, 187, 1),
+        80px 80px 0 0 rgba(187, 187, 187, 1),
+        120px 80px 0 0 rgba(187, 187, 187, 1),
+        180px 80px 0 0 rgba(187, 187, 187, 1),
+        220px 80px 0 0 rgba(187, 187, 187, 1),
+        240px 80px 0 0 rgba(187, 187, 187, 1),
+        260px 80px 0 0 rgba(187, 187, 187, 1),
+        280px 80px 0 0 rgba(187, 187, 187, 1),
+        80px 100px 0 0 rgba(187, 187, 187, 1),
+        140px 100px 0 0 rgba(187, 187, 187, 1),
+        160px 100px 0 0 rgba(187, 187, 187, 1),
+        280px 100px 0 0 rgba(187, 187, 187, 1),
+        80px 120px 0 0 rgba(187, 187, 187, 1),
+        280px 120px 0 0 rgba(187, 187, 187, 1);
+      height: 20px;
+      width: 20px;
+    }
+    75.01%,
+    100% {
+      box-shadow: 220px 20px 0 0 rgba(187, 187, 187, 1),
+        280px 20px 0 0 rgba(187, 187, 187, 1),
+        20px 40px 0 0 rgba(187, 187, 187, 1),
+        80px 40px 0 0 rgba(187, 187, 187, 1),
+        140px 40px 0 0 rgba(187, 187, 187, 1),
+        160px 40px 0 0 rgba(187, 187, 187, 1),
+        220px 40px 0 0 rgba(187, 187, 187, 1),
+        280px 40px 0 0 rgba(187, 187, 187, 1),
+        20px 60px 0 0 rgba(187, 187, 187, 1),
+        80px 60px 0 0 rgba(187, 187, 187, 1),
+        120px 60px 0 0 rgba(187, 187, 187, 1),
+        180px 60px 0 0 rgba(187, 187, 187, 1),
+        220px 60px 0 0 rgba(187, 187, 187, 1),
+        240px 60px 0 0 rgba(187, 187, 187, 1),
+        260px 60px 0 0 rgba(187, 187, 187, 1),
+        280px 60px 0 0 rgba(187, 187, 187, 1),
+        20px 80px 0 0 rgba(187, 187, 187, 1),
+        40px 80px 0 0 rgba(187, 187, 187, 1),
+        60px 80px 0 0 rgba(187, 187, 187, 1),
+        80px 80px 0 0 rgba(187, 187, 187, 1),
+        120px 80px 0 0 rgba(187, 187, 187, 1),
+        180px 80px 0 0 rgba(187, 187, 187, 1),
+        280px 80px 0 0 rgba(187, 187, 187, 1),
+        80px 100px 0 0 rgba(187, 187, 187, 1),
+        120px 100px 0 0 rgba(187, 187, 187, 1),
+        180px 100px 0 0 rgba(187, 187, 187, 1),
+        280px 100px 0 0 rgba(187, 187, 187, 1),
+        80px 120px 0 0 rgba(187, 187, 187, 1),
+        140px 120px 0 0 rgba(187, 187, 187, 1),
+        160px 120px 0 0 rgba(187, 187, 187, 1);
+      height: 20px;
+      width: 20px;
+    }
   }
 }


### PR DESCRIPTION
This is a hacky way of modularizing the CSS to avoid name conflicts. We
wrap all CSS definitions inside a top-level class
`pixel-art-react-container` and then make the top-level React component
use that class. This way, as long as the consumer of this pixel art
library doesn't use `.pixel-art-react-container` somewhere, there will
be no chance of the consumer and the pixel art library colliding on
class names.